### PR TITLE
feat: add training dashboard with various charts and filters

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,6 +17,8 @@
         "@nivo/core": "^0.88.0",
         "@nivo/line": "^0.88.0",
         "@nivo/pie": "^0.88.0",
+        "@nivo/radial-bar": "^0.88.0",
+        "@nivo/stream": "^0.88.0",
         "@std/text": "npm:@jsr/std__text@^1.0.16",
         "@t3-oss/env-nextjs": "^0.13.10",
         "@tanstack/react-query": "^5.90.15",
@@ -596,7 +598,13 @@
 
     "@nivo/pie": ["@nivo/pie@0.88.0", "", { "dependencies": { "@nivo/arcs": "0.88.0", "@nivo/colors": "0.88.0", "@nivo/core": "0.88.0", "@nivo/legends": "0.88.0", "@nivo/tooltip": "0.88.0", "@types/d3-shape": "^3.1.6", "d3-shape": "^3.2.0" }, "peerDependencies": { "react": ">= 16.14.0 < 19.0.0" } }, "sha512-BE6dFWlGne1SnaEkFHNbg0sZBiwtcIqBFwmMRJ0F11SiKOzVeJyq3KiyY1I2ySSCx5VR1V8/MNBXzXFu3vJMAQ=="],
 
+    "@nivo/polar-axes": ["@nivo/polar-axes@0.88.0", "", { "dependencies": { "@nivo/arcs": "0.88.0", "@nivo/core": "0.88.0", "@nivo/scales": "0.88.0", "@react-spring/web": "9.4.5 || ^9.7.2" }, "peerDependencies": { "react": ">= 16.14.0 < 19.0.0" } }, "sha512-HXJgYLdHnGprncJC2Nb7VhcPfZGNoJYc1551AQ5z8Fb0wPLbj9OhwrrV5Q9xWrKmi3L+Ad5NWgWf8jt/dEHLoQ=="],
+
+    "@nivo/radial-bar": ["@nivo/radial-bar@0.88.0", "", { "dependencies": { "@nivo/arcs": "0.88.0", "@nivo/colors": "0.88.0", "@nivo/core": "0.88.0", "@nivo/legends": "0.88.0", "@nivo/polar-axes": "0.88.0", "@nivo/scales": "0.88.0", "@nivo/tooltip": "0.88.0", "@react-spring/web": "9.4.5 || ^9.7.2", "@types/d3-scale": "^4.0.8", "@types/d3-shape": "^3.1.6", "d3-scale": "^4.0.2", "d3-shape": "^3.2.0" }, "peerDependencies": { "react": ">= 16.14.0 < 19.0.0" } }, "sha512-T5VNhpf9vGvq6nCnnjr/lVbM06b1fwrOxhAQMWMgalW5aUBxB8EOpu6C5dmtg6vFvmotjXeMjyz6I3/riPOMhQ=="],
+
     "@nivo/scales": ["@nivo/scales@0.88.0", "", { "dependencies": { "@types/d3-scale": "^4.0.8", "@types/d3-time": "^1.1.1", "@types/d3-time-format": "^3.0.0", "d3-scale": "^4.0.2", "d3-time": "^1.0.11", "d3-time-format": "^3.0.0", "lodash": "^4.17.21" } }, "sha512-HbpxkQp6tHCltZ1yDGeqdLcaJl5ze54NPjurfGtx/Uq+H5IQoBd4Tln49bUar5CsFAMsXw8yF1HQvASr7I1SIA=="],
+
+    "@nivo/stream": ["@nivo/stream@0.88.0", "", { "dependencies": { "@nivo/axes": "0.88.0", "@nivo/colors": "0.88.0", "@nivo/core": "0.88.0", "@nivo/legends": "0.88.0", "@nivo/scales": "0.88.0", "@nivo/tooltip": "0.88.0", "@react-spring/web": "9.4.5 || ^9.7.2", "@types/d3-shape": "^3.1.6", "d3-shape": "^3.2.0" }, "peerDependencies": { "react": ">= 16.14.0 < 19.0.0" } }, "sha512-XN7/6bcqAaTw7SpejahZWBrYo9l5dOc95sgxLiR7PYdF5sncb0YWsaGHswey2mfr26QxIqs/xFHZ5O0oXBztJQ=="],
 
     "@nivo/tooltip": ["@nivo/tooltip@0.88.0", "", { "dependencies": { "@nivo/core": "0.88.0", "@react-spring/web": "9.4.5 || ^9.7.2" }, "peerDependencies": { "react": ">= 16.14.0 < 19.0.0" } }, "sha512-iEjVfQA8gumAzg/yUinjTwswygCkE5Iwuo8opwnrbpNIqMrleBV+EAKIgB0PrzepIoW8CFG/SJhoiRfbU8jhOw=="],
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "@nivo/core": "^0.88.0",
     "@nivo/line": "^0.88.0",
     "@nivo/pie": "^0.88.0",
+    "@nivo/radial-bar": "^0.88.0",
+    "@nivo/stream": "^0.88.0",
     "@std/text": "npm:@jsr/std__text@^1.0.16",
     "@t3-oss/env-nextjs": "^0.13.10",
     "@tanstack/react-query": "^5.90.15",

--- a/src/app/_components/charts/ascents-by-style/ascents-by-style.tsx
+++ b/src/app/_components/charts/ascents-by-style/ascents-by-style.tsx
@@ -1,4 +1,3 @@
-import type { OrdinalColorScaleConfig } from '@nivo/colors'
 import type { PropertyAccessor } from '@nivo/core'
 import { type ComputedDatum, ResponsivePie } from '@nivo/pie'
 import { useMemo } from 'react'
@@ -8,7 +7,12 @@ import {
   getAscentsByStyle,
 } from '../ascents-by-style/get-ascents-by-style'
 import { ChartContainer } from '../chart-container/chart-container'
-import { DEFAULT_PIE_MARGIN, defaultMotionConfig, theme } from '../constants'
+import {
+  DEFAULT_PIE_MARGIN,
+  defaultMotionConfig,
+  pieColorsGetter,
+  theme,
+} from '../constants'
 
 export function AscentsByStyle({ ascents }: { ascents: Ascent[] }) {
   const data = useMemo(() => getAscentsByStyle(ascents), [ascents])
@@ -27,7 +31,8 @@ export function AscentsByStyle({ ascents }: { ascents: Ascent[] }) {
         animate
         arcLabel={arcLabel}
         arcLabelsTextColor="var(--surface-1)"
-        colors={getChartColor}
+        // @ts-expect-error
+        colors={pieColorsGetter}
         data={data}
         innerRadius={0.5}
         margin={DEFAULT_PIE_MARGIN}
@@ -37,7 +42,3 @@ export function AscentsByStyle({ ascents }: { ascents: Ascent[] }) {
     </ChartContainer>
   )
 }
-
-const getChartColor: OrdinalColorScaleConfig<
-  Omit<ComputedDatum<AscentByStyle>, 'color' | 'fill' | 'arc'>
-> = ({ data }) => data.color

--- a/src/app/_components/charts/training-sessions-indoor-vs-outdoor/get-sessions-indoor-vs-outdoor.ts
+++ b/src/app/_components/charts/training-sessions-indoor-vs-outdoor/get-sessions-indoor-vs-outdoor.ts
@@ -1,0 +1,50 @@
+import type { TrainingSession } from '~/schema/training'
+import type { LocationType } from '../../filter-bar/types'
+import { isIndoorSession } from '../../wrap-up/_components/training-summary/helpers'
+
+type SessionsIndoorVsOutdoor = {
+  id: LocationType
+  label: LocationType
+  value: number
+  color: string
+}[]
+
+export function getSessionsIndoorVsOutdoor(
+  sessions: TrainingSession[],
+): SessionsIndoorVsOutdoor {
+  if (sessions.length === 0) return []
+
+  let indoorCount = 0
+  let outdoorCount = 0
+
+  for (const session of sessions) {
+    const { sessionType } = session
+    if (sessionType === 'Out') {
+      outdoorCount++
+    } else if (isIndoorSession({ sessionType })) {
+      indoorCount++
+    }
+  }
+
+  const result: SessionsIndoorVsOutdoor = []
+
+  if (indoorCount > 0) {
+    result.push({
+      color: 'var(--indoor)',
+      id: 'Indoor',
+      label: 'Indoor',
+      value: indoorCount,
+    })
+  }
+
+  if (outdoorCount > 0) {
+    result.push({
+      color: 'var(--outdoor)',
+      id: 'Outdoor',
+      label: 'Outdoor',
+      value: outdoorCount,
+    })
+  }
+
+  return result
+}

--- a/src/app/_components/charts/training-sessions-indoor-vs-outdoor/training-sessions-indoor-vs-outdoor.tsx
+++ b/src/app/_components/charts/training-sessions-indoor-vs-outdoor/training-sessions-indoor-vs-outdoor.tsx
@@ -1,0 +1,58 @@
+import type { PropertyAccessor } from '@nivo/core'
+import { type ComputedDatum, ResponsivePie } from '@nivo/pie'
+import { useMemo } from 'react'
+import type { TrainingSession } from '~/schema/training'
+import { ChartContainer } from '../chart-container/chart-container'
+import {
+  DEFAULT_PIE_MARGIN,
+  defaultMotionConfig,
+  pieColorsGetter,
+  theme,
+} from '../constants'
+import { getSessionsIndoorVsOutdoor } from './get-sessions-indoor-vs-outdoor'
+
+type SessionLocationMetric = {
+  id: string
+  label: string
+  value: number
+  color: string
+}
+
+export function TrainingSessionsIndoorVsOutdoor({
+  trainingSessions,
+}: {
+  trainingSessions: TrainingSession[]
+}) {
+  const data = useMemo(
+    () => getSessionsIndoorVsOutdoor(trainingSessions),
+    [trainingSessions],
+  )
+
+  const totalSessions = data.reduce((sum, item) => sum + item.value, 0)
+
+  const arcLabel: PropertyAccessor<
+    ComputedDatum<SessionLocationMetric>,
+    string
+  > = datum =>
+    `${datum.value} (${Math.round((datum.value / totalSessions) * 100)}%)`
+
+  if (data.length === 0) return null
+  if (data.length === 1) return null
+
+  return (
+    <ChartContainer caption="Indoor vs Outdoor Sessions">
+      <ResponsivePie
+        animate
+        arcLabel={arcLabel}
+        arcLabelsTextColor="var(--surface-1)"
+        // @ts-expect-error
+        colors={pieColorsGetter}
+        data={data}
+        innerRadius={0.5}
+        margin={DEFAULT_PIE_MARGIN}
+        motionConfig={defaultMotionConfig}
+        theme={theme}
+      />
+    </ChartContainer>
+  )
+}

--- a/src/app/_components/charts/training-sessions-per-discipline/get-sessions-per-discipline.ts
+++ b/src/app/_components/charts/training-sessions-per-discipline/get-sessions-per-discipline.ts
@@ -1,0 +1,40 @@
+import { CLIMBING_DISCIPLINE_TO_COLOR } from '~/constants/ascents'
+import type { TrainingSession } from '~/schema/training'
+
+type SessionsPerDiscipline = {
+  id: NonNullable<TrainingSession['climbingDiscipline']>
+  label: NonNullable<TrainingSession['climbingDiscipline']>
+  value: number
+  color: string
+}[]
+
+export function getSessionsPerDiscipline(
+  sessions: TrainingSession[],
+): SessionsPerDiscipline {
+  if (sessions.length === 0) return []
+
+  const sessionsWithDiscipline = sessions.filter(
+    session => session.climbingDiscipline !== undefined,
+  )
+
+  const disciplineCounts = sessionsWithDiscipline.reduce(
+    (acc, { climbingDiscipline }) => {
+      if (!climbingDiscipline) return acc
+      acc[climbingDiscipline] = (acc[climbingDiscipline] ?? 0) + 1
+      return acc
+    },
+    {} as Record<NonNullable<TrainingSession['climbingDiscipline']>, number>,
+  )
+
+  return Object.entries(disciplineCounts)
+    .map(([discipline, count]) => ({
+      color:
+        CLIMBING_DISCIPLINE_TO_COLOR[
+          discipline as keyof typeof CLIMBING_DISCIPLINE_TO_COLOR
+        ] ?? 'var(--gray-5)',
+      id: discipline as NonNullable<TrainingSession['climbingDiscipline']>,
+      label: discipline as NonNullable<TrainingSession['climbingDiscipline']>,
+      value: count,
+    }))
+    .sort((a, b) => b.value - a.value)
+}

--- a/src/app/_components/charts/training-sessions-per-discipline/training-sessions-per-discipline.tsx
+++ b/src/app/_components/charts/training-sessions-per-discipline/training-sessions-per-discipline.tsx
@@ -1,0 +1,57 @@
+import type { PropertyAccessor } from '@nivo/core'
+import { type ComputedDatum, ResponsivePie } from '@nivo/pie'
+import { useMemo } from 'react'
+import type { TrainingSession } from '~/schema/training'
+import { ChartContainer } from '../chart-container/chart-container'
+import {
+  DEFAULT_PIE_MARGIN,
+  defaultMotionConfig,
+  pieColorsGetter,
+  theme,
+} from '../constants'
+import { getSessionsPerDiscipline } from './get-sessions-per-discipline'
+
+type SessionDisciplineMetric = {
+  id: string
+  label: string
+  value: number
+  color: string
+}
+
+export function TrainingSessionsPerDiscipline({
+  trainingSessions,
+}: {
+  trainingSessions: TrainingSession[]
+}) {
+  const data = useMemo(
+    () => getSessionsPerDiscipline(trainingSessions),
+    [trainingSessions],
+  )
+
+  const totalSessions = data.reduce((sum, item) => sum + item.value, 0)
+
+  const arcLabel: PropertyAccessor<
+    ComputedDatum<SessionDisciplineMetric>,
+    string
+  > = datum =>
+    `${datum.value} (${Math.round((datum.value / totalSessions) * 100)}%)`
+
+  if (data.length === 0) return null
+  if (data.length === 1) return null
+
+  return (
+    <ChartContainer caption="Training Sessions by Discipline">
+      <ResponsivePie
+        animate
+        arcLabel={arcLabel}
+        arcLabelsTextColor="var(--surface-1)"
+        colors={pieColorsGetter}
+        data={data}
+        innerRadius={0.5}
+        margin={DEFAULT_PIE_MARGIN}
+        motionConfig={defaultMotionConfig}
+        theme={theme}
+      />
+    </ChartContainer>
+  )
+}

--- a/src/app/_components/charts/training-sessions-per-year/get-sessions-per-year.ts
+++ b/src/app/_components/charts/training-sessions-per-year/get-sessions-per-year.ts
@@ -1,0 +1,91 @@
+import { createYearList } from '~/data/helpers'
+import type { TrainingSession } from '~/schema/training'
+import { isIndoorSession } from '../../wrap-up/_components/training-summary/helpers'
+
+export type SessionsPerYear = {
+  year: number
+  indoorRoute: number
+  indoorRouteColor: string
+  indoorBoulder: number
+  indoorBoulderColor: string
+  outdoorRoute: number
+  outdoorRouteColor: string
+  outdoorBoulder: number
+  outdoorBoulderColor: string
+}
+
+export function getSessionsPerYear(
+  sessions: TrainingSession[],
+): SessionsPerYear[] {
+  if (sessions.length === 0) return []
+
+  const years = createYearList(sessions, {
+    descending: false,
+    continuous: true,
+  })
+
+  const sessionsPerYearMap = new Map<
+    number,
+    {
+      indoorBoulder: number
+      indoorRoute: number
+      outdoorBoulder: number
+      outdoorRoute: number
+    }
+  >()
+
+  for (const session of sessions) {
+    const sessionYear = new Date(session.date).getFullYear()
+
+    let counts = sessionsPerYearMap.get(sessionYear)
+    if (!counts) {
+      counts = {
+        indoorBoulder: 0,
+        indoorRoute: 0,
+        outdoorBoulder: 0,
+        outdoorRoute: 0,
+      }
+      sessionsPerYearMap.set(sessionYear, counts)
+    }
+
+    const { sessionType, climbingDiscipline } = session
+    const isIndoor = isIndoorSession({ sessionType })
+    const isOutdoor = sessionType === 'Out'
+
+    if (isIndoor && climbingDiscipline === 'Boulder') {
+      counts.indoorBoulder++
+    } else if (isIndoor && climbingDiscipline === 'Route') {
+      counts.indoorRoute++
+    } else if (isOutdoor && climbingDiscipline === 'Boulder') {
+      counts.outdoorBoulder++
+    } else if (isOutdoor && climbingDiscipline === 'Route') {
+      counts.outdoorRoute++
+    }
+  }
+
+  const result: SessionsPerYear[] = []
+
+  for (const year of years) {
+    const counts = sessionsPerYearMap.get(year) ?? {
+      indoorBoulder: 0,
+      indoorRoute: 0,
+      outdoorBoulder: 0,
+      outdoorRoute: 0,
+    }
+
+    // Add single entry per year with all 4 categories
+    result.push({
+      year,
+      indoorRoute: counts.indoorRoute,
+      indoorRouteColor: 'var(--indoorRoute)',
+      indoorBoulder: counts.indoorBoulder,
+      indoorBoulderColor: 'var(--indoorBoulder)',
+      outdoorRoute: counts.outdoorRoute,
+      outdoorRouteColor: 'var(--route)',
+      outdoorBoulder: counts.outdoorBoulder,
+      outdoorBoulderColor: 'var(--boulder)',
+    })
+  }
+
+  return result
+}

--- a/src/app/_components/charts/training-sessions-per-year/training-sessions-per-year.tsx
+++ b/src/app/_components/charts/training-sessions-per-year/training-sessions-per-year.tsx
@@ -1,0 +1,93 @@
+import { ResponsiveStream } from '@nivo/stream'
+import { useCallback, useMemo } from 'react'
+import type { TrainingSession } from '~/schema/training'
+import { ChartContainer } from '../chart-container/chart-container'
+import { defaultMotionConfig, theme } from '../constants'
+import type { SessionsPerYear } from './get-sessions-per-year'
+import { getSessionsPerYear } from './get-sessions-per-year'
+
+const STREAM_KEYS = [
+  'indoorRoute',
+  'indoorBoulder',
+  'outdoorRoute',
+  'outdoorBoulder',
+] as const satisfies (keyof SessionsPerYear)[]
+const chartMargins = { bottom: 50, left: 60, right: 10, top: 10 }
+
+export function TrainingSessionsPerYear({
+  trainingSessions,
+}: {
+  trainingSessions: TrainingSession[]
+}) {
+  const data = useMemo(
+    () => getSessionsPerYear(trainingSessions),
+    [trainingSessions],
+  )
+
+  const axisLeft = useMemo(
+    () => ({
+      tickSize: 0,
+      tickPadding: 0,
+      renderTick: () => null,
+    }),
+    [],
+  )
+
+  // Create a mapping of index to year for axis formatting
+  const yearsByIndex = useMemo(() => data.map(d => d.year), [data])
+
+  const axisBottom = useMemo(
+    () => ({
+      format: (index: number | string) => {
+        const numericIndex = typeof index === 'number' ? index : Number(index)
+
+        if (!Number.isFinite(numericIndex)) {
+          return ''
+        }
+
+        if (numericIndex < 0 || numericIndex >= yearsByIndex.length) {
+          return ''
+        }
+
+        const year = yearsByIndex[numericIndex]
+        return year ? `'${String(year).slice(-2)}` : ''
+      },
+      tickSize: 5,
+      tickPadding: 5,
+      tickRotation: 0,
+      legend: 'Years',
+      legendOffset: 40,
+      legendPosition: 'middle' as const,
+    }),
+    [yearsByIndex],
+  )
+
+  const getSessionColor = useCallback(
+    ({ id }: { id: string | number }) => {
+      const sampleData = data[0]
+      if (!sampleData) return 'var(--gray-5)'
+      const key = `${id}Color` as keyof typeof sampleData
+      return (sampleData[key] as string) ?? 'var(--gray-5)'
+    },
+    [data],
+  )
+
+  if (data.length === 0) return null
+
+  return (
+    <ChartContainer caption="Training Sessions per Year (Indoor/Outdoor by Discipline)">
+      <ResponsiveStream
+        animate
+        axisBottom={axisBottom}
+        axisLeft={axisLeft}
+        colors={getSessionColor}
+        data={data}
+        keys={STREAM_KEYS}
+        margin={chartMargins}
+        motionConfig={defaultMotionConfig}
+        offsetType="expand"
+        theme={theme}
+      />
+    </ChartContainer>
+  )
+}

--- a/src/app/_components/charts/training-sessions-radial/get-sessions-radial-data.ts
+++ b/src/app/_components/charts/training-sessions-radial/get-sessions-radial-data.ts
@@ -1,0 +1,172 @@
+import type { TrainingSession } from '~/schema/training'
+
+type RadialBarData = Array<{
+  id: string
+  data: Array<{
+    x: string
+    y: number
+  }>
+}>
+
+const ENERGY_SYSTEM_COLORS = {
+  AA: 'var(--energySystemAA)',
+  AE: 'var(--energySystemAE)',
+  AL: 'var(--energySystemAL)',
+} as const
+
+const ENERGY_SYSTEM_LABELS = {
+  AA: 'Anaerobic Alactic',
+  AE: 'Aerobic',
+  AL: 'Anaerobic Lactic',
+} as const
+
+const ANATOMICAL_REGION_COLORS = {
+  Ar: 'var(--anatomicalRegionAr)',
+  Fi: 'var(--anatomicalRegionFi)',
+  Ge: 'var(--anatomicalRegionGe)',
+} as const
+
+const ANATOMICAL_REGION_LABELS = {
+  Ar: 'Arms',
+  Fi: 'Fingers',
+  Ge: 'General',
+} as const
+
+export function getSessionsRadialData(sessions: TrainingSession[]): {
+  data: RadialBarData
+  colors: Record<string, string>
+  legendData: Array<{ id: string; label: string; color: string }>
+  totals: Record<string, number>
+} {
+  if (sessions.length === 0)
+    return { colors: {}, data: [], legendData: [], totals: {} }
+
+  const sessionsWithEnergySystem = sessions.filter(
+    session => session.energySystem !== undefined,
+  )
+
+  const sessionsWithRegion = sessions.filter(
+    session => session.anatomicalRegion !== undefined,
+  )
+
+  const energySystemCounts = sessionsWithEnergySystem.reduce(
+    (acc, { energySystem }) => {
+      if (!energySystem) return acc
+      acc[energySystem] = (acc[energySystem] ?? 0) + 1
+      return acc
+    },
+    {} as Record<NonNullable<TrainingSession['energySystem']>, number>,
+  )
+
+  const regionCounts = sessionsWithRegion.reduce(
+    (acc, { anatomicalRegion }) => {
+      if (!anatomicalRegion) return acc
+      acc[anatomicalRegion] = (acc[anatomicalRegion] ?? 0) + 1
+      return acc
+    },
+    {} as Record<NonNullable<TrainingSession['anatomicalRegion']>, number>,
+  )
+
+  const colors: Record<string, string> = {}
+
+  // Build Energy System ring data
+  const energySystemData: Array<{ x: string; y: number }> = Object.entries(
+    energySystemCounts,
+  )
+    .map(([system, count]) => ({
+      x:
+        ENERGY_SYSTEM_LABELS[system as keyof typeof ENERGY_SYSTEM_LABELS] ??
+        system,
+      y: count,
+    }))
+    .sort((a, b) => b.y - a.y)
+
+  for (const item of energySystemData) {
+    const systemKey = (
+      Object.keys(ENERGY_SYSTEM_LABELS) as Array<
+        keyof typeof ENERGY_SYSTEM_LABELS
+      >
+    ).find(key => ENERGY_SYSTEM_LABELS[key] === item.x)
+    if (systemKey) {
+      colors[item.x] = ENERGY_SYSTEM_COLORS[systemKey]
+    }
+  }
+
+  // Build Anatomical Region ring data
+  const anatomicalRegionData: Array<{ x: string; y: number }> = Object.entries(
+    regionCounts,
+  )
+    .map(([region, count]) => ({
+      x:
+        ANATOMICAL_REGION_LABELS[
+          region as keyof typeof ANATOMICAL_REGION_LABELS
+        ] ?? region,
+      y: count,
+    }))
+    .sort((a, b) => b.y - a.y)
+
+  for (const item of anatomicalRegionData) {
+    const regionKey = (
+      Object.keys(ANATOMICAL_REGION_LABELS) as Array<
+        keyof typeof ANATOMICAL_REGION_LABELS
+      >
+    ).find(key => ANATOMICAL_REGION_LABELS[key] === item.x)
+    if (regionKey) {
+      colors[item.x] = ANATOMICAL_REGION_COLORS[regionKey]
+    }
+  }
+
+  const data: RadialBarData = [
+    {
+      data: energySystemData,
+      id: 'Energy System',
+    },
+    {
+      data: anatomicalRegionData,
+      id: 'Anatomical Region',
+    },
+  ]
+
+  const totals = {
+    'Energy System': energySystemData.reduce((sum, item) => sum + item.y, 0),
+    'Anatomical Region': anatomicalRegionData.reduce(
+      (sum, item) => sum + item.y,
+      0,
+    ),
+  }
+
+  const legendData = [
+    {
+      color: ENERGY_SYSTEM_COLORS.AA,
+      id: 'AA',
+      label: ENERGY_SYSTEM_LABELS.AA,
+    },
+    {
+      color: ENERGY_SYSTEM_COLORS.AE,
+      id: 'AE',
+      label: ENERGY_SYSTEM_LABELS.AE,
+    },
+    {
+      color: ENERGY_SYSTEM_COLORS.AL,
+      id: 'AL',
+      label: ENERGY_SYSTEM_LABELS.AL,
+    },
+    {
+      color: ANATOMICAL_REGION_COLORS.Ar,
+      id: 'Ar',
+      label: ANATOMICAL_REGION_LABELS.Ar,
+    },
+    {
+      color: ANATOMICAL_REGION_COLORS.Fi,
+      id: 'Fi',
+      label: ANATOMICAL_REGION_LABELS.Fi,
+    },
+    {
+      color: ANATOMICAL_REGION_COLORS.Ge,
+      id: 'Ge',
+      label: ANATOMICAL_REGION_LABELS.Ge,
+    },
+  ]
+
+  return { colors, data, legendData, totals }
+}

--- a/src/app/_components/charts/training-sessions-radial/training-sessions-radial.tsx
+++ b/src/app/_components/charts/training-sessions-radial/training-sessions-radial.tsx
@@ -1,0 +1,80 @@
+import type { LegendProps } from '@nivo/legends'
+import { ResponsiveRadialBar } from '@nivo/radial-bar'
+import { useCallback, useMemo } from 'react'
+import type { TrainingSession } from '~/schema/training'
+import { ChartContainer } from '../chart-container/chart-container'
+import { theme } from '../constants'
+import { getSessionsRadialData } from './get-sessions-radial-data'
+
+export function TrainingSessionsRadial({
+  trainingSessions,
+}: {
+  trainingSessions: TrainingSession[]
+}) {
+  const { data, colors, legendData, totals } = useMemo(
+    () => getSessionsRadialData(trainingSessions),
+    [trainingSessions],
+  )
+
+  const getBarColor = useCallback(
+    // biome-ignore lint/suspicious/noExplicitAny: Idk what to put in there
+    ({ data: d }: any) => colors[d.x] ?? 'var(--gray-5)',
+    [colors],
+  )
+
+  const formatLabel = useCallback(
+    (datum: {
+      id: string
+      groupId: string
+      value: number
+      stackedValue: number
+    }) => {
+      const total = totals[datum.groupId]
+      if (!total) return '0%'
+      const percentage = Math.round((datum.value / total) * 100)
+      return `${percentage}%`
+    },
+    [totals],
+  )
+  const chartMargins = useMemo(
+    () => ({ bottom: 20, left: 75, right: 160, top: 20 }),
+    [],
+  )
+
+  const legends = useMemo<LegendProps[]>(
+    () => [
+      {
+        anchor: 'right',
+        data: legendData,
+        direction: 'column',
+        itemDirection: 'left-to-right',
+        itemHeight: 20,
+        itemWidth: 100,
+        symbolShape: 'circle',
+        symbolSize: 12,
+        translateX: 140,
+      },
+    ],
+    [legendData],
+  )
+
+  if (data.length === 0) return null
+  return (
+    <ChartContainer caption="Training Sessions Distribution">
+      <ResponsiveRadialBar
+        colors={getBarColor}
+        data={data}
+        enableCircularGrid={true}
+        enableLabels
+        enableRadialGrid={false}
+        enableTracks={false}
+        innerRadius={0.3}
+        label={formatLabel}
+        legends={legends}
+        margin={chartMargins}
+        padding={0.4}
+        theme={theme}
+      />
+    </ChartContainer>
+  )
+}

--- a/src/app/_components/filter-bar/_components/training-dashboard-filter-bar.tsx
+++ b/src/app/_components/filter-bar/_components/training-dashboard-filter-bar.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react'
+import { createYearList } from '~/data/helpers.ts'
+import { useTrainingSessionsQueryState } from '~/hooks/use-training-sessions-query-state.ts'
+import { AVAILABLE_CLIMBING_DISCIPLINE } from '~/schema/ascent'
+import { PERIOD } from '~/schema/generic'
+import type { TrainingSessionListProps } from '~/schema/training.ts'
+import { createChangeHandler } from '../helpers'
+import { StickyFilterBar } from '../sticky-filter-bar'
+import { type FilterConfig, LOCATION_TYPES } from '../types'
+
+export function TrainingDashboardFilterBar({
+  trainingSessions,
+}: TrainingSessionListProps) {
+  const yearList = useMemo(
+    () =>
+      createYearList(trainingSessions, {
+        descending: true,
+        continuous: false,
+      }).map(String),
+    [trainingSessions],
+  )
+
+  const {
+    selectedYear,
+    selectedPeriod,
+    selectedDiscipline,
+    selectedLocationType,
+    setYear,
+    setPeriod,
+    setDiscipline,
+    setLocationType,
+  } = useTrainingSessionsQueryState()
+
+  const filters = useMemo<FilterConfig[]>(
+    () =>
+      [
+        {
+          handleChange: createChangeHandler(setYear),
+          name: 'Year',
+          options: yearList,
+          selectedValue: selectedYear,
+          title: 'Year',
+        },
+        {
+          handleChange: createChangeHandler(setLocationType),
+          name: 'Location Type',
+          options: LOCATION_TYPES,
+          selectedValue: selectedLocationType,
+          title: 'Indoor / Outdoor',
+        },
+        {
+          handleChange: createChangeHandler(setDiscipline),
+          name: 'Discipline',
+          options: AVAILABLE_CLIMBING_DISCIPLINE,
+          selectedValue: selectedDiscipline,
+          title: 'Climbing Discipline',
+        },
+        {
+          handleChange: createChangeHandler(setPeriod),
+          name: 'Period',
+          options: PERIOD,
+          selectedValue: selectedPeriod,
+          title: 'Period',
+        },
+      ] as const satisfies FilterConfig[],
+    [
+      selectedDiscipline,
+      selectedLocationType,
+      selectedPeriod,
+      selectedYear,
+      setDiscipline,
+      setLocationType,
+      setPeriod,
+      setYear,
+      yearList,
+    ],
+  )
+
+  return <StickyFilterBar filters={filters} showSearch={false} />
+}

--- a/src/app/_components/filter-bar/types.ts
+++ b/src/app/_components/filter-bar/types.ts
@@ -1,5 +1,8 @@
 import type { ChangeEventHandler } from 'react'
 
+export const LOCATION_TYPES = ['Indoor', 'Outdoor'] as const
+export type LocationType = (typeof LOCATION_TYPES)[number]
+
 export type FilterConfig<T extends string | number = string> = {
   name: string
   title: string

--- a/src/app/_components/navigation/constants.ts
+++ b/src/app/_components/navigation/constants.ts
@@ -45,6 +45,11 @@ export const NAVIGATION_ITEMS = [
       },
       {
         type: 'link',
+        href: LINKS.trainingSessionsDashboard,
+        label: '📊 Dashboard',
+      },
+      {
+        type: 'link',
         href: LINKS.trainingSessionsCalendar,
         label: '📅 Calendar',
       },

--- a/src/app/_components/training-dashboard/training-dashboard.tsx
+++ b/src/app/_components/training-dashboard/training-dashboard.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { Link } from 'next-view-transitions'
+import { memo, Suspense } from 'react'
+import NotFound from '~/app/not-found.tsx'
+import { LINKS } from '~/constants/links'
+import { useTrainingSessionsFilter } from '~/hooks/use-training-sessions-filter'
+import type { TrainingSessionListProps } from '~/schema/training.ts'
+import { TrainingSessionsIndoorVsOutdoor } from '../charts/training-sessions-indoor-vs-outdoor/training-sessions-indoor-vs-outdoor.tsx'
+import { TrainingSessionsPerDiscipline } from '../charts/training-sessions-per-discipline/training-sessions-per-discipline.tsx'
+import { TrainingSessionsPerYear } from '../charts/training-sessions-per-year/training-sessions-per-year.tsx'
+import { TrainingSessionsRadial } from '../charts/training-sessions-radial/training-sessions-radial.tsx'
+import styles from '../dashboard/dashboard.module.css'
+import { TrainingDashboardFilterBar } from '../filter-bar/_components/training-dashboard-filter-bar'
+import { Loader } from '../loader/loader.tsx'
+
+export function TrainingDashboard({
+  trainingSessions,
+}: TrainingSessionListProps) {
+  const filteredTrainingSessions = useTrainingSessionsFilter(
+    trainingSessions ?? [],
+  )
+
+  if (trainingSessions.length === 0) return <NotFound />
+
+  return (
+    <div className="flex flexColumn alignCenter gridFullWidth">
+      <TrainingDashboardFilterBar trainingSessions={trainingSessions} />
+      <Suspense fallback={<Loader />}>
+        <DashboardStats trainingSessions={filteredTrainingSessions} />
+      </Suspense>
+    </div>
+  )
+}
+
+const DashboardStats = memo(function DashboardStatistics({
+  trainingSessions,
+}: TrainingSessionListProps) {
+  return trainingSessions.length === 0 ? (
+    <div className="flexColumn gap w100 padding">
+      <h2>Nothing there...</h2>
+      <p>
+        Try{' '}
+        <Link href={LINKS.trainingSessionForm}>
+          logging new training sessions
+        </Link>
+        .
+      </p>
+    </div>
+  ) : (
+    <div className={styles.container}>
+      <TrainingSessionsPerDiscipline trainingSessions={trainingSessions} />
+      <TrainingSessionsIndoorVsOutdoor trainingSessions={trainingSessions} />
+      <TrainingSessionsPerYear trainingSessions={trainingSessions} />
+      <TrainingSessionsRadial trainingSessions={trainingSessions} />
+    </div>
+  )
+})

--- a/src/app/_components/wrap-up/_components/training-summary/helpers.ts
+++ b/src/app/_components/wrap-up/_components/training-summary/helpers.ts
@@ -70,8 +70,7 @@ export function categorizeSessions(
 
   for (const session of sessions) {
     const { sessionType, climbingDiscipline } = session
-    const isIndoor =
-      sessionType !== undefined && INDOOR_SESSION_TYPES.includes(sessionType)
+    const isIndoor = isIndoorSession({ sessionType })
     const isOutdoor = sessionType === 'Out'
 
     if (isIndoor) {
@@ -102,4 +101,12 @@ type CategorizedSessionsOutput = {
   indoorBoulder: TrainingSession[]
   outdoorRoute: TrainingSession[]
   outdoorBoulder: TrainingSession[]
+}
+
+export function isIndoorSession({
+  sessionType,
+}: {
+  sessionType?: TrainingSession['sessionType']
+}): boolean {
+  return sessionType !== undefined && INDOOR_SESSION_TYPES.includes(sessionType)
 }

--- a/src/app/training-sessions/dashboard/page.tsx
+++ b/src/app/training-sessions/dashboard/page.tsx
@@ -1,0 +1,24 @@
+import type { Metadata } from 'next'
+import { Suspense } from 'react'
+import { Loader } from '~/app/_components/loader/loader'
+import Layout from '~/app/_components/page-layout/page-layout'
+import { TrainingDashboard } from '~/app/_components/training-dashboard/training-dashboard'
+import { api } from '~/trpc/server'
+
+export default async function Page() {
+  const trainingSessions = await api.training.getAll()
+
+  return (
+    <Layout title="Training Dashboard">
+      <Suspense fallback={<Loader />}>
+        <TrainingDashboard trainingSessions={trainingSessions} />
+      </Suspense>
+    </Layout>
+  )
+}
+
+export const metadata: Metadata = {
+  description: 'Visualize training session statistics and patterns',
+  keywords: ['training', 'statistics', 'charts', 'dashboard', 'filter'],
+  title: 'Training Dashboard 📊',
+}

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -18,6 +18,7 @@ export const LINKS = {
   ascentsBarcode: '/ascents/barcode',
   ascentsQrCode: '/ascents/qr-code',
   trainingSessionsList: '/training-sessions',
+  trainingSessionsDashboard: '/training-sessions/dashboard',
   trainingSessionsCalendar: '/training-sessions/calendar',
   trainingSessionsBarcode: '/training-sessions/barcode',
   trainingSessionsQrCode: '/training-sessions/qr-code',

--- a/src/helpers/filter-training.ts
+++ b/src/helpers/filter-training.ts
@@ -1,6 +1,8 @@
 import { isDateInRange } from '@edouardmisset/date'
 import { isDateInYear } from '@edouardmisset/date/is-date-in-year.ts'
 import { stringEqualsCaseInsensitive } from '@edouardmisset/text/string-equals.ts'
+import type { LocationType } from '~/app/_components/filter-bar/types'
+import { isIndoorSession } from '~/app/_components/wrap-up/_components/training-summary/helpers'
 import { PERIOD_TO_DATES, type Period } from '~/schema/generic'
 import type { LoadCategory, TrainingSession } from '~/schema/training.ts'
 
@@ -10,6 +12,7 @@ type OptionalTrainingInput = Partial<
   year?: number
   load?: LoadCategory
   period?: Period
+  locationType?: LocationType
 }
 
 /**
@@ -36,6 +39,7 @@ export function filterTrainingSessions(
     volume,
     year,
     period,
+    locationType,
   } = filters ?? {}
 
   if (!trainingSessions || trainingSessions.length === 0) {
@@ -47,6 +51,7 @@ export function filterTrainingSessions(
 
   return trainingSessions.filter(trainingSession => {
     const trainingSessionDate = new Date(trainingSession.date)
+
     return (
       (gymCrag === undefined ||
         stringEqualsCaseInsensitive(trainingSession?.gymCrag ?? '', gymCrag)) &&
@@ -64,7 +69,11 @@ export function filterTrainingSessions(
         trainingSession.sessionType === sessionType) &&
       (volume === undefined || trainingSession.volume === volume) &&
       (period === undefined ||
-        isDateInRange(trainingSessionDate, { ...PERIOD_TO_DATES[period] }))
+        isDateInRange(trainingSessionDate, { ...PERIOD_TO_DATES[period] })) &&
+      (locationType === undefined ||
+        (locationType === 'Indoor'
+          ? isIndoorSession({ sessionType: trainingSession.sessionType })
+          : trainingSession.sessionType === 'Out'))
     )
   })
 }

--- a/src/hooks/query-state-slices/use-location-type-query-state.ts
+++ b/src/hooks/query-state-slices/use-location-type-query-state.ts
@@ -1,0 +1,19 @@
+import { type UseQueryStateReturn, useQueryState } from 'nuqs'
+import { ALL_VALUE } from '~/app/_components/dashboard/constants'
+import type { OrAll } from '~/app/_components/dashboard/types'
+import {
+  LOCATION_TYPES,
+  type LocationType,
+} from '~/app/_components/filter-bar/types'
+
+export const useLocationTypeQueryState = (): UseQueryStateReturn<
+  OrAll<LocationType>,
+  OrAll<LocationType>
+> =>
+  useQueryState<OrAll<LocationType>>('locationType', {
+    defaultValue: ALL_VALUE,
+    parse: value =>
+      value === ALL_VALUE || LOCATION_TYPES.includes(value as LocationType)
+        ? (value as OrAll<LocationType>)
+        : ALL_VALUE,
+  })

--- a/src/hooks/use-training-sessions-filter.ts
+++ b/src/hooks/use-training-sessions-filter.ts
@@ -15,23 +15,30 @@ export function useTrainingSessionsFilter(
     selectedLoad,
     selectedLocation,
     selectedPeriod,
+    selectedDiscipline,
+    selectedLocationType,
   } = useTrainingSessionsQueryState()
 
   const filteredTrainingSessions = useMemo(() => {
     const selectedYearNumber = Number(selectedYear)
+
     return filterTrainingSessions(trainingSessions, {
+      climbingDiscipline: normalizeFilterValue(selectedDiscipline),
       gymCrag: normalizeFilterValue(selectedLocation),
       load: normalizeFilterValue(selectedLoad),
+      locationType: normalizeFilterValue(selectedLocationType),
+      period: normalizeFilterValue(selectedPeriod),
       sessionType: normalizeFilterValue(selectedSessionType),
       year:
         selectedYear !== ALL_VALUE && isValidNumber(selectedYearNumber)
           ? selectedYearNumber
           : undefined,
-      period: normalizeFilterValue(selectedPeriod),
     })
   }, [
+    selectedDiscipline,
     selectedLoad,
     selectedLocation,
+    selectedLocationType,
     selectedPeriod,
     selectedSessionType,
     selectedYear,

--- a/src/hooks/use-training-sessions-query-state.ts
+++ b/src/hooks/use-training-sessions-query-state.ts
@@ -1,8 +1,11 @@
 import type { OrAll } from '~/app/_components/dashboard/types'
+import type { LocationType } from '~/app/_components/filter-bar/types'
 import type { Period } from '~/schema/generic'
 import type { LoadCategory, TrainingSession } from '~/schema/training'
+import { useDisciplineQueryState } from './query-state-slices/use-discipline-query-state'
 import { useLoadQueryState } from './query-state-slices/use-load-query-state'
 import { useLocationQueryState } from './query-state-slices/use-location-query-state'
+import { useLocationTypeQueryState } from './query-state-slices/use-location-type-query-state'
 import { usePeriodQueryState } from './query-state-slices/use-period-query-state'
 import { useSessionTypeQueryState } from './query-state-slices/use-session-type-query-state'
 import { useYearQueryState } from './query-state-slices/use-year-query-state'
@@ -14,6 +17,8 @@ export const useTrainingSessionsQueryState =
     const [selectedSessionType, setSessionType] = useSessionTypeQueryState()
     const [selectedLoad, setLoad] = useLoadQueryState()
     const [selectedLocation, setLocation] = useLocationQueryState()
+    const [selectedDiscipline, setDiscipline] = useDisciplineQueryState()
+    const [selectedLocationType, setLocationType] = useLocationTypeQueryState()
 
     return {
       selectedLoad,
@@ -21,11 +26,15 @@ export const useTrainingSessionsQueryState =
       selectedPeriod,
       selectedSessionType,
       selectedYear,
+      selectedDiscipline,
+      selectedLocationType,
       setLoad,
       setLocation,
       setPeriod,
       setSessionType,
       setYear,
+      setDiscipline,
+      setLocationType,
     }
   }
 
@@ -35,6 +44,8 @@ type UseTrainingSessionsQueryStateReturn = {
   selectedPeriod: OrAll<Period>
   selectedSessionType: OrAll<NonNullable<TrainingSession['sessionType']>>
   selectedYear: OrAll<string>
+  selectedDiscipline: OrAll<NonNullable<TrainingSession['climbingDiscipline']>>
+  selectedLocationType: OrAll<LocationType>
   setLoad: (load: OrAll<LoadCategory>) => void
   setLocation: (
     location: OrAll<NonNullable<TrainingSession['gymCrag']>>,
@@ -44,4 +55,8 @@ type UseTrainingSessionsQueryStateReturn = {
     sessionType: OrAll<NonNullable<TrainingSession['sessionType']>>,
   ) => void
   setYear: (year: OrAll<string>) => void
+  setDiscipline: (
+    discipline: OrAll<NonNullable<TrainingSession['climbingDiscipline']>>,
+  ) => void
+  setLocationType: (locationType: OrAll<LocationType>) => void
 }

--- a/src/styles/climbing-colors.css
+++ b/src/styles/climbing-colors.css
@@ -32,6 +32,22 @@
   --endurance: var(--orange-5);
   --enduranceHigh: var(--orange-9);
 
+  --indoorLow: var(--blue-1);
+  --indoor: var(--blue-5);
+  --indoorHigh: var(--blue-9);
+
+  /* Scale down saturation (chroma) for indoor route/boulder oklch() colors */
+  --indoorSaturation: 0.1;
+  --indoorLightness: 0.1;
+  --indoorRoute: oklch(
+    from var(--route) calc(l + var(--indoorLightness))
+      calc(c * var(--indoorSaturation)) h
+  );
+  --indoorBoulder: oklch(
+    from var(--boulder) calc(l + var(--indoorLightness))
+      calc(c * var(--indoorSaturation)) h
+  );
+
   --otherTrainingLow: var(--gray-1);
   --otherTraining: var(--gray-5);
   --otherTrainingHigh: var(--gray-7);
@@ -51,6 +67,16 @@
   --taperedLow: var(--violet-1);
   --tapered: var(--violet-5);
   --taperedHigh: var(--violet-9);
+
+  /* ENERGY SYSTEMS */
+  --energySystemAA: var(--red-5);
+  --energySystemAL: var(--purple-5);
+  --energySystemAE: var(--teal-5);
+
+  /* ANATOMICAL REGIONS */
+  --anatomicalRegionAr: var(--blue-5);
+  --anatomicalRegionFi: var(--pink-5);
+  --anatomicalRegionGe: var(--teal-5);
 
   /* DISCIPLINE */
   --boulder: var(--pink-4);


### PR DESCRIPTION
- Introduced new charts for visualizing training sessions:
  - Indoor vs Outdoor Sessions
  - Sessions per Discipline
  - Sessions per Year
  - Radial distribution of sessions based on energy systems and anatomical regions.

- Implemented a filter bar for selecting year, location type, discipline, and period.
- Added utility functions for processing training session data.
- Updated navigation to include a link to the new training dashboard.
- Enhanced styling with new color variables for indoor/outdoor sessions and energy systems.