### PR TITLE
Add Top Ten Evolution chart

### DIFF
--- a/src/app/_components/charts/constants.ts
+++ b/src/app/_components/charts/constants.ts
@@ -10,6 +10,7 @@ export const AXIS_TICK_STYLE = {
 
 export const AXIS_LABEL_STYLE = {
   fill: 'var(--text-1)',
+  position: 'middle',
 } as const
 
 export const TOOLTIP_STYLE = {

--- a/src/app/_components/charts/top-ten-evolution/get-top-ten-evolution.test.ts
+++ b/src/app/_components/charts/top-ten-evolution/get-top-ten-evolution.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import { sampleAscents } from '~/backup/sample-ascents'
+import type { Ascent } from '~/schema/ascent'
+import { getTopTenEvolution } from './get-top-ten-evolution'
+
+function countDisciplineForYear(
+  ascents: Ascent[],
+  discipline: Ascent['climbingDiscipline'],
+  year: number,
+): number {
+  return ascents.filter(
+    ascent =>
+      ascent.climbingDiscipline === discipline && new Date(ascent.date).getFullYear() === year,
+  ).length
+}
+
+describe('getTopTenEvolution', () => {
+  it('should return empty array for empty input', () => {
+    const result = getTopTenEvolution([])
+    expect(result).toEqual([])
+  })
+
+  it('should return one entry for a single-year dataset', () => {
+    const ascentsIn2024 = sampleAscents.filter(({ date }) => new Date(date).getFullYear() === 2_024)
+
+    const result = getTopTenEvolution(ascentsIn2024)
+
+    expect(result).toEqual([
+      {
+        Boulder: countDisciplineForYear(ascentsIn2024, 'Boulder', 2_024),
+        Route: countDisciplineForYear(ascentsIn2024, 'Route', 2_024),
+        ascents: ascentsIn2024.length,
+        outdoorDays: 17,
+        topTenScore: 9_250,
+        year: 2_024,
+      },
+    ])
+  })
+
+  it('should return a continuous year range with zeroes for missing years', () => {
+    const [firstAscent, secondAscent, thirdAscent] = sampleAscents
+
+    if (!firstAscent || !secondAscent || !thirdAscent)
+      throw new Error('Expected at least three sample ascents')
+
+    const ascents: Ascent[] = [
+      {
+        ...firstAscent,
+        _id: 'top-ten-evolution-1',
+        date: '2022-01-10',
+      },
+      {
+        ...secondAscent,
+        _id: 'top-ten-evolution-2',
+        date: '2024-03-12',
+      },
+      {
+        ...thirdAscent,
+        _id: 'top-ten-evolution-3',
+        date: '2024-09-05',
+      },
+    ]
+
+    const result = getTopTenEvolution(ascents)
+
+    expect(result).toEqual([
+      {
+        Boulder: countDisciplineForYear(ascents, 'Boulder', 2_022),
+        Route: countDisciplineForYear(ascents, 'Route', 2_022),
+        ascents: 1,
+        outdoorDays: 1,
+        topTenScore: 850,
+        year: 2_022,
+      },
+      {
+        Boulder: 0,
+        Route: 0,
+        ascents: 0,
+        outdoorDays: 0,
+        topTenScore: 0,
+        year: 2_023,
+      },
+      {
+        Boulder: countDisciplineForYear(ascents, 'Boulder', 2_024),
+        Route: countDisciplineForYear(ascents, 'Route', 2_024),
+        ascents: 2,
+        outdoorDays: 2,
+        topTenScore: 1_750,
+        year: 2_024,
+      },
+    ])
+  })
+})

--- a/src/app/_components/charts/top-ten-evolution/get-top-ten-evolution.ts
+++ b/src/app/_components/charts/top-ten-evolution/get-top-ten-evolution.ts
@@ -1,0 +1,41 @@
+import { isDateInYear } from '@edouardmisset/date/is-date-in-year.ts'
+import { createYearList } from '~/data/helpers'
+import { calculateTopTenScore } from '~/helpers/calculate-top-ten'
+import { countUniqueDates } from '~/helpers/count-unique-dates'
+import type { Ascent } from '~/schema/ascent'
+
+export type TopTenEvolutionDatum = {
+  Boulder: number
+  Route: number
+  ascents: number
+  outdoorDays: number
+  topTenScore: number
+  year: number
+}
+
+export function getTopTenEvolution(ascents: Ascent[]): TopTenEvolutionDatum[] {
+  if (ascents.length === 0) return []
+
+  const years = createYearList(ascents, { descending: false, continuous: true })
+
+  return years.map(year => {
+    const ascentsInYear = ascents.filter(({ date }) => isDateInYear(date, year))
+    const { Boulder, Route } = ascentsInYear.reduce(
+      (acc, { climbingDiscipline }) => {
+        if (climbingDiscipline === 'Boulder') acc.Boulder++
+        if (climbingDiscipline === 'Route') acc.Route++
+        return acc
+      },
+      { Boulder: 0, Route: 0 },
+    )
+
+    return {
+      Boulder,
+      Route,
+      ascents: ascentsInYear.length,
+      outdoorDays: countUniqueDates(ascentsInYear),
+      topTenScore: calculateTopTenScore(ascentsInYear),
+      year,
+    }
+  })
+}

--- a/src/app/_components/charts/top-ten-evolution/top-ten-evolution.tsx
+++ b/src/app/_components/charts/top-ten-evolution/top-ten-evolution.tsx
@@ -1,0 +1,112 @@
+import { useMemo } from 'react'
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  ResponsiveContainer,
+  YAxis,
+} from 'recharts'
+
+import { ChartContainer } from '../chart-container/chart-container'
+import { ChartTooltip, ChartXAxis } from '../chart-elements'
+import {
+  AXIS_LABEL_STYLE,
+  AXIS_TICK_STYLE,
+  BAR_CATEGORY_GAP,
+  formatYearTick,
+  GRID_STROKE,
+} from '../constants'
+
+import { CLIMBING_DISCIPLINE_TO_COLOR } from '~/constants/ascents'
+import { frenchNumberFormatter } from '~/helpers/number-formatter'
+import type { Ascent } from '~/schema/ascent'
+import { getTopTenEvolution } from './get-top-ten-evolution'
+
+const AXIS_LABELS = {
+  ascents: '# Ascents',
+  boulders: 'Boulders',
+  outdoorDays: 'Outdoor Days',
+  routes: 'Routes',
+  score: 'Top Ten Score',
+  years: 'Years',
+}
+
+const DOT_STYLE = { r: 4 }
+
+export function TopTenEvolution({ ascents }: { ascents: Ascent[] }) {
+  const data = useMemo(() => getTopTenEvolution(ascents), [ascents])
+
+  if (data.length === 0) return
+
+  return (
+    <ChartContainer caption='Top Ten Evolution'>
+      <ResponsiveContainer height='100%' width='100%'>
+        <ComposedChart barCategoryGap={BAR_CATEGORY_GAP} data={data}>
+          <CartesianGrid stroke={GRID_STROKE} vertical={false} />
+          <ChartXAxis dataKey='year' labelText={AXIS_LABELS.years} tickFormatter={formatYearTick} />
+          <YAxis
+            yAxisId='left'
+            label={{
+              ...AXIS_LABEL_STYLE,
+              angle: -90,
+              value: AXIS_LABELS.score,
+            }}
+            tick={AXIS_TICK_STYLE}
+            tickFormatter={value => frenchNumberFormatter.format(Number(value))}
+          />
+          <YAxis
+            yAxisId='right'
+            allowDecimals={false}
+            domain={[0, 'dataMax']}
+            label={{
+              ...AXIS_LABEL_STYLE,
+              angle: -90,
+              value: AXIS_LABELS.ascents,
+            }}
+            orientation='right'
+            tick={AXIS_TICK_STYLE}
+          />
+          <ChartTooltip
+            formatter={(value, name) => {
+              if (name === AXIS_LABELS.score)
+                return [frenchNumberFormatter.format(Number(value)), name]
+              return [value, name]
+            }}
+          />
+          <Legend align='center' iconType='circle' layout='horizontal' verticalAlign='top' />
+          <Bar
+            dataKey='Boulder'
+            fill={CLIMBING_DISCIPLINE_TO_COLOR.Boulder}
+            name={AXIS_LABELS.boulders}
+            stackId='ascents'
+            yAxisId='right'
+          />
+          <Bar
+            dataKey='Route'
+            fill={CLIMBING_DISCIPLINE_TO_COLOR.Route}
+            name={AXIS_LABELS.routes}
+            stackId='ascents'
+            yAxisId='right'
+          />
+          <Bar
+            dataKey='outdoorDays'
+            fill='var(--outdoor)'
+            name={AXIS_LABELS.outdoorDays}
+            yAxisId='right'
+          />
+          <Line
+            dataKey='topTenScore'
+            dot={DOT_STYLE}
+            name={AXIS_LABELS.score}
+            stroke='var(--flash)'
+            strokeWidth={2}
+            type='natural'
+            yAxisId='left'
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </ChartContainer>
+  )
+}

--- a/src/app/_components/charts/training-sessions-distribution/training-sessions-distribution.tsx
+++ b/src/app/_components/charts/training-sessions-distribution/training-sessions-distribution.tsx
@@ -72,7 +72,7 @@ export function TrainingSessionsDistribution({
   }, [data, colors])
 
   const xAxisLabel = useMemo<LabelProps>(
-    () => ({ value: 'Number of Sessions', offset: 20, position: 'bottom', ...AXIS_LABEL_STYLE }),
+    () => ({ ...AXIS_LABEL_STYLE, value: 'Number of Sessions', offset: 20, position: 'bottom' }),
     [],
   )
 

--- a/src/app/_components/dashboard/dashboard-statistics.tsx
+++ b/src/app/_components/dashboard/dashboard-statistics.tsx
@@ -55,6 +55,10 @@ const DistanceClimbedPerYear = dynamic(
     ),
   { ssr: false },
 )
+const TopTenEvolution = dynamic(
+  () => import('../charts/top-ten-evolution/top-ten-evolution.tsx').then(m => m.TopTenEvolution),
+  { ssr: false },
+)
 const TriesByGrade = dynamic(
   () => import('../charts/tries-by-grade/tries-by-grade.tsx').then(m => m.TriesByGrade),
   { ssr: false },
@@ -86,6 +90,7 @@ function DashboardStatisticsComponent(props: DashboardStatisticsProps) {
       <AscentsPerDisciplinePerGrade ascents={ascents} />
       <DistanceClimbedPerYear ascents={ascents} />
       <AscentsByGradesPerCrag ascents={ascents} />
+      <TopTenEvolution ascents={ascents} />
     </div>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Top Ten Evolution" chart to the dashboard that visualizes yearly progression of climbing performance metrics including Boulder and Route ascent counts, total ascents, outdoor climbing days, and an overall top-ten score displayed across dual Y-axes for comprehensive performance analysis.

* **Tests**
  * Added unit tests covering evolution data computation for empty inputs, single-year datasets, and continuous year ranges with missing data scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->