### PR TITLE
Add Ascents Volume and Max/Average Grade chart

### DIFF
--- a/src/app/_components/charts/ascents-volume-and-grades-per-year/ascents-volume-and-grades-per-year.tsx
+++ b/src/app/_components/charts/ascents-volume-and-grades-per-year/ascents-volume-and-grades-per-year.tsx
@@ -1,0 +1,232 @@
+import { useMemo } from 'react'
+import {
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  ResponsiveContainer,
+  YAxis,
+} from 'recharts'
+
+import { ChartContainer } from '../chart-container/chart-container'
+import { ChartTooltip, ChartXAxis } from '../chart-elements'
+import {
+  AXIS_LABEL_STYLE,
+  AXIS_TICK_STYLE,
+  BAR_CATEGORY_GAP,
+  formatYearTick,
+  GRID_STROKE,
+} from '../constants'
+
+import { CLIMBING_DISCIPLINE_TO_COLOR } from '~/constants/ascents'
+import { fromNumberToGrade } from '~/helpers/grade-converter'
+import { GRADE_TO_NUMBER, type Ascent } from '~/schema/ascent'
+import { getAscentsVolumeAndGradesPerYear } from './get-ascents-volume-and-grades-per-year'
+
+const AXIS_LABELS = {
+  ascents: '# Ascents',
+  grades: 'Grades',
+  years: 'Years',
+}
+
+const CHART_LABELS = {
+  avgBoulderGrade: 'Average Boulder Grade',
+  avgRouteGrade: 'Average Route Grade',
+  boulderAscents: 'Boulders',
+  maxBoulderGrade: 'Max Boulder Grade',
+  maxRouteGrade: 'Max Route Grade',
+  routeAscents: 'Routes',
+}
+
+const DISCIPLINE_SHADED_COLORS = {
+  Boulder: {
+    average: 'color-mix(in oklch, var(--boulder) 65%, white)',
+    max: 'color-mix(in oklch, var(--boulder) 70%, black)',
+  },
+  Route: {
+    average: 'color-mix(in oklch, var(--route) 65%, white)',
+    max: 'color-mix(in oklch, var(--route) 70%, black)',
+  },
+} as const
+
+const GRADE_VALUES = Object.values(GRADE_TO_NUMBER)
+const MIN_GRADE_NUMBER = Math.min(...GRADE_VALUES)
+const MAX_GRADE_NUMBER = Math.max(...GRADE_VALUES)
+const GRADE_AXIS_HEADROOM = 1
+const HALF_AXIS_POSITION_NUMERATOR = 1
+const HALF_AXIS_POSITION_DENOMINATOR = 2
+const HALF_AXIS_POSITION = HALF_AXIS_POSITION_NUMERATOR / HALF_AXIS_POSITION_DENOMINATOR
+
+function clampGrade(grade: number): number {
+  return Math.min(MAX_GRADE_NUMBER, Math.max(MIN_GRADE_NUMBER, grade))
+}
+
+function clampOptionalGrade(grade: number | undefined): number | undefined {
+  if (grade === undefined) return undefined
+  return clampGrade(grade)
+}
+
+function getLowerBoundForHalfAxisStart(minGrade: number, upperBound: number): number {
+  return (minGrade - HALF_AXIS_POSITION * upperBound) / (1 - HALF_AXIS_POSITION)
+}
+
+const GRADE_TICKS = GRADE_VALUES
+
+const DOTTED_LINE_STROKE = '6 6'
+const ASCENTS_AXIS_STEP = 100
+
+function roundUpToStep(value: number, step: number): number {
+  return Math.ceil(value / step) * step
+}
+
+function formatGradeTick(value: unknown): string {
+  if (typeof value !== 'number') return String(value)
+  return fromNumberToGrade(clampGrade(Math.round(value)))
+}
+
+export function AscentsVolumeAndGradesPerYear({ ascents }: { ascents: Ascent[] }) {
+  const data = useMemo(
+    () =>
+      getAscentsVolumeAndGradesPerYear(ascents).map(datum => ({
+        ...datum,
+        avgBoulderGrade: clampOptionalGrade(datum.avgBoulderGrade),
+        avgRouteGrade: clampOptionalGrade(datum.avgRouteGrade),
+        maxBoulderGrade: clampOptionalGrade(datum.maxBoulderGrade),
+        maxRouteGrade: clampOptionalGrade(datum.maxRouteGrade),
+      })),
+    [ascents],
+  )
+
+  const gradeDomain = useMemo<[number, number]>(() => {
+    const grades = data.flatMap(datum => [
+      datum.avgBoulderGrade,
+      datum.avgRouteGrade,
+      datum.maxBoulderGrade,
+      datum.maxRouteGrade,
+    ])
+
+    const minGrade = grades.reduce<number>(
+      (min, value) => (typeof value === 'number' ? Math.min(min, value) : min),
+      MAX_GRADE_NUMBER,
+    )
+
+    const maxGrade = grades.reduce<number>(
+      (max, value) => (typeof value === 'number' ? Math.max(max, value) : max),
+      MIN_GRADE_NUMBER,
+    )
+
+    const upperBound = maxGrade + GRADE_AXIS_HEADROOM
+    const lowerBound = getLowerBoundForHalfAxisStart(minGrade, upperBound)
+
+    return [lowerBound, upperBound]
+  }, [data])
+
+  const gradeTicks = useMemo(() => {
+    const [minDomain, maxDomain] = gradeDomain
+    return GRADE_TICKS.filter(tick => tick >= minDomain && tick <= maxDomain)
+  }, [gradeDomain])
+
+  const uniqueYearsCount = new Set(data.map(({ year }) => year)).size
+  const hasDisciplineData = data.some(({ Boulder, Route }) => Boulder > 0 || Route > 0)
+
+  if (data.length === 0) return
+  if (uniqueYearsCount <= 1) return
+  if (!hasDisciplineData) return
+
+  return (
+    <ChartContainer caption='Ascents Volume and Max / Average Grade Evolution'>
+      <ResponsiveContainer height='100%' width='100%'>
+        <ComposedChart barCategoryGap={BAR_CATEGORY_GAP} data={data}>
+          <CartesianGrid stroke={GRID_STROKE} vertical={false} />
+          <ChartXAxis dataKey='year' labelText={AXIS_LABELS.years} tickFormatter={formatYearTick} />
+          <YAxis
+            yAxisId='left'
+            domain={gradeDomain}
+            ticks={gradeTicks}
+            label={{
+              ...AXIS_LABEL_STYLE,
+              angle: -90,
+              value: AXIS_LABELS.grades,
+            }}
+            tick={AXIS_TICK_STYLE}
+            tickFormatter={formatGradeTick}
+          />
+          <YAxis
+            yAxisId='right'
+            allowDecimals={false}
+            domain={[0, dataMax => roundUpToStep(Number(dataMax), ASCENTS_AXIS_STEP)]}
+            label={{
+              ...AXIS_LABEL_STYLE,
+              angle: -90,
+              value: AXIS_LABELS.ascents,
+            }}
+            orientation='right'
+            tick={AXIS_TICK_STYLE}
+          />
+          <ChartTooltip
+            formatter={(value, name) => {
+              if (typeof value !== 'number') return [value, name]
+              if (!name?.toString()?.includes('Grade')) return [value, name]
+
+              return [fromNumberToGrade(clampGrade(Math.round(value))), name]
+            }}
+          />
+          <Legend align='center' iconType='circle' layout='horizontal' verticalAlign='top' />
+
+          <Bar
+            dataKey='Boulder'
+            fill={CLIMBING_DISCIPLINE_TO_COLOR.Boulder}
+            name={CHART_LABELS.boulderAscents}
+            yAxisId='right'
+          />
+          <Bar
+            dataKey='Route'
+            fill={CLIMBING_DISCIPLINE_TO_COLOR.Route}
+            name={CHART_LABELS.routeAscents}
+            yAxisId='right'
+          />
+
+          <Line
+            dataKey='maxBoulderGrade'
+            dot={false}
+            name={CHART_LABELS.maxBoulderGrade}
+            stroke={DISCIPLINE_SHADED_COLORS.Boulder.max}
+            strokeWidth={2}
+            type='natural'
+            yAxisId='left'
+          />
+          <Line
+            dataKey='maxRouteGrade'
+            dot={false}
+            name={CHART_LABELS.maxRouteGrade}
+            stroke={DISCIPLINE_SHADED_COLORS.Route.max}
+            strokeWidth={2}
+            type='natural'
+            yAxisId='left'
+          />
+          <Line
+            dataKey='avgBoulderGrade'
+            dot={false}
+            name={CHART_LABELS.avgBoulderGrade}
+            stroke={DISCIPLINE_SHADED_COLORS.Boulder.average}
+            strokeDasharray={DOTTED_LINE_STROKE}
+            strokeWidth={2}
+            type='natural'
+            yAxisId='left'
+          />
+          <Line
+            dataKey='avgRouteGrade'
+            dot={false}
+            name={CHART_LABELS.avgRouteGrade}
+            stroke={DISCIPLINE_SHADED_COLORS.Route.average}
+            strokeDasharray={DOTTED_LINE_STROKE}
+            strokeWidth={2}
+            type='natural'
+            yAxisId='left'
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </ChartContainer>
+  )
+}

--- a/src/app/_components/charts/ascents-volume-and-grades-per-year/get-ascents-volume-and-grades-per-year.test.ts
+++ b/src/app/_components/charts/ascents-volume-and-grades-per-year/get-ascents-volume-and-grades-per-year.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { sampleAscents } from '~/backup/sample-ascents'
+import { fromGradeToNumber } from '~/helpers/grade-converter'
+import type { Ascent } from '~/schema/ascent'
+import { getAscentsVolumeAndGradesPerYear } from './get-ascents-volume-and-grades-per-year'
+
+describe('getAscentsVolumeAndGradesPerYear', () => {
+  it('should return empty array for empty input', () => {
+    const result = getAscentsVolumeAndGradesPerYear([])
+    expect(result).toEqual([])
+  })
+
+  it('should return yearly discipline counts with max and average grades', () => {
+    const [firstAscent, secondAscent, thirdAscent, fourthAscent, fifthAscent] = sampleAscents
+
+    if (!firstAscent || !secondAscent || !thirdAscent || !fourthAscent || !fifthAscent)
+      throw new Error('Expected at least five sample ascents')
+
+    const ascents: Ascent[] = [
+      {
+        ...firstAscent,
+        _id: 'volume-and-grade-1',
+        climbingDiscipline: 'Route',
+        date: '2023-01-10',
+        topoGrade: '6a',
+      },
+      {
+        ...secondAscent,
+        _id: 'volume-and-grade-2',
+        climbingDiscipline: 'Route',
+        date: '2023-05-08',
+        topoGrade: '6b',
+      },
+      {
+        ...thirdAscent,
+        _id: 'volume-and-grade-3',
+        climbingDiscipline: 'Boulder',
+        date: '2023-08-02',
+        topoGrade: '7a',
+      },
+      {
+        ...fourthAscent,
+        _id: 'volume-and-grade-4',
+        climbingDiscipline: 'Boulder',
+        date: '2025-03-17',
+        topoGrade: '7b+',
+      },
+      {
+        ...fifthAscent,
+        _id: 'volume-and-grade-5',
+        climbingDiscipline: 'Multi-Pitch',
+        date: '2025-09-13',
+        topoGrade: '8a',
+      },
+    ]
+
+    const result = getAscentsVolumeAndGradesPerYear(ascents)
+
+    expect(result).toEqual([
+      {
+        Boulder: 1,
+        Route: 2,
+        avgBoulderGrade: fromGradeToNumber('7a'),
+        avgRouteGrade: fromGradeToNumber('6a+'),
+        maxBoulderGrade: fromGradeToNumber('7a'),
+        maxRouteGrade: fromGradeToNumber('6b'),
+        year: 2_023,
+      },
+      {
+        Boulder: 0,
+        Route: 0,
+        avgBoulderGrade: undefined,
+        avgRouteGrade: undefined,
+        maxBoulderGrade: undefined,
+        maxRouteGrade: undefined,
+        year: 2_024,
+      },
+      {
+        Boulder: 1,
+        Route: 0,
+        avgBoulderGrade: fromGradeToNumber('7b+'),
+        avgRouteGrade: undefined,
+        maxBoulderGrade: fromGradeToNumber('7b+'),
+        maxRouteGrade: undefined,
+        year: 2_025,
+      },
+    ])
+  })
+})

--- a/src/app/_components/charts/ascents-volume-and-grades-per-year/get-ascents-volume-and-grades-per-year.ts
+++ b/src/app/_components/charts/ascents-volume-and-grades-per-year/get-ascents-volume-and-grades-per-year.ts
@@ -1,0 +1,59 @@
+import { average } from '@edouardmisset/math/average.ts'
+import { isDateInYear } from '@edouardmisset/date/is-date-in-year.ts'
+import { createYearList } from '~/data/helpers'
+import { fromGradeToNumber } from '~/helpers/grade-converter'
+import type { Ascent } from '~/schema/ascent'
+
+export type AscentsVolumeAndGradesPerYearDatum = {
+  Boulder: number
+  Route: number
+  avgBoulderGrade: number | undefined
+  avgRouteGrade: number | undefined
+  maxBoulderGrade: number | undefined
+  maxRouteGrade: number | undefined
+  year: number
+}
+
+function getGradeStats(gradeNumbers: number[]): {
+  avg: number | undefined
+  max: number | undefined
+} {
+  if (gradeNumbers.length === 0) return { avg: undefined, max: undefined }
+
+  return {
+    avg: Math.round(average(...gradeNumbers)),
+    max: Math.max(...gradeNumbers),
+  }
+}
+
+export function getAscentsVolumeAndGradesPerYear(
+  ascents: Ascent[],
+): AscentsVolumeAndGradesPerYearDatum[] {
+  if (ascents.length === 0) return []
+
+  const years = createYearList(ascents, { descending: false, continuous: true })
+
+  return years.map(year => {
+    const boulderGrades: number[] = []
+    const routeGrades: number[] = []
+
+    for (const { climbingDiscipline, date, topoGrade } of ascents) {
+      if (!isDateInYear(date, year)) continue
+      if (climbingDiscipline === 'Boulder') boulderGrades.push(fromGradeToNumber(topoGrade))
+      if (climbingDiscipline === 'Route') routeGrades.push(fromGradeToNumber(topoGrade))
+    }
+
+    const boulderGradeStats = getGradeStats(boulderGrades)
+    const routeGradeStats = getGradeStats(routeGrades)
+
+    return {
+      Boulder: boulderGrades.length,
+      Route: routeGrades.length,
+      avgBoulderGrade: boulderGradeStats.avg,
+      avgRouteGrade: routeGradeStats.avg,
+      maxBoulderGrade: boulderGradeStats.max,
+      maxRouteGrade: routeGradeStats.max,
+      year,
+    }
+  })
+}

--- a/src/app/_components/dashboard/dashboard-statistics.tsx
+++ b/src/app/_components/dashboard/dashboard-statistics.tsx
@@ -30,10 +30,10 @@ const AscentsPerDisciplinePerGrade = dynamic(
     ),
   { ssr: false },
 )
-const AscentsPerDisciplinePerYear = dynamic(
+const AscentsVolumeAndGradesPerYear = dynamic(
   () =>
-    import('../charts/ascents-per-discipline-per-year/ascents-per-discipline-per-year.tsx').then(
-      m => m.AscentsPerDisciplinePerYear,
+    import('../charts/ascents-volume-and-grades-per-year/ascents-volume-and-grades-per-year.tsx').then(
+      m => m.AscentsVolumeAndGradesPerYear,
     ),
   { ssr: false },
 )
@@ -85,7 +85,7 @@ function DashboardStatisticsComponent(props: DashboardStatisticsProps) {
       <AscentsPerYearByGrade ascents={ascents} />
       <AscentsByStyle ascents={ascents} />
       <AscentsPerDiscipline ascents={ascents} />
-      <AscentsPerDisciplinePerYear ascents={ascents} />
+      <AscentsVolumeAndGradesPerYear ascents={ascents} />
       <TriesByGrade ascents={ascents} />
       <AscentsPerDisciplinePerGrade ascents={ascents} />
       <DistanceClimbedPerYear ascents={ascents} />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new annual ascents and grades chart displaying climbing volume and grade statistics by year, with separate tracking for boulder and route disciplines. The visualization shows ascent counts, average grades, and maximum grades achieved per discipline and year with responsive design and dynamic scaling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->