### PR TITLE
Replace next-view-transitions with native Next.js view transitions

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -29,6 +29,7 @@ const config: NextConfig = {
       bodySizeLimit: '12mb',
     },
     useCache: true,
+    viewTransition: true,
   },
 }
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "fflate": "^0.8.3",
     "lucide-react": "^1.23.0",
     "next": "^16.2.12",
-    "next-view-transitions": "^0.3.5",
     "nuqs": "^2.9.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       next:
         specifier: ^16.2.12
         version: 16.2.12(@playwright/test@1.62.0)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      next-view-transitions:
-        specifier: ^0.3.5
-        version: 0.3.5(next@16.2.12(@playwright/test@1.62.0)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nuqs:
         specifier: ^2.9.2
         version: 2.9.2(next@16.2.12(@playwright/test@1.62.0)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
@@ -2438,11 +2435,6 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.11.1:
-    resolution: {integrity: sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   baseline-browser-mapping@2.11.3:
     resolution: {integrity: sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==}
     engines: {node: '>=6.0.0'}
@@ -3844,13 +3836,6 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
-  next-view-transitions@0.3.5:
-    resolution: {integrity: sha512-yP8OPNydLmKpmE94hLurLGEzPsUy1uyl9iSv8oxaC2JwhSXTD86SVwk1NMMQT7Ado4kMENDJ7fNBIXHy3GU/Lg==}
-    peerDependencies:
-      next: '>=14.0.0'
-      react: '>=18.2.0 || ^19.0.0'
-      react-dom: '>=18.2.0 || ^19.0.0'
 
   next@16.2.12:
     resolution: {integrity: sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==}
@@ -6559,8 +6544,6 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.11.1: {}
-
   baseline-browser-mapping@2.11.3: {}
 
   brace-expansion@1.1.16:
@@ -6578,7 +6561,7 @@ snapshots:
 
   browserslist@4.28.7:
     dependencies:
-      baseline-browser-mapping: 2.11.1
+      baseline-browser-mapping: 2.11.3
       caniuse-lite: 1.0.30001806
       electron-to-chromium: 1.5.395
       node-releases: 2.0.51
@@ -7540,7 +7523,7 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.2
+      flatted: 3.4.3
       keyv: 4.5.4
 
   flat-cache@6.1.23:
@@ -8092,12 +8075,6 @@ snapshots:
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
-
-  next-view-transitions@0.3.5(next@16.2.12(@playwright/test@1.62.0)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
-    dependencies:
-      next: 16.2.12(@playwright/test@1.62.0)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
 
   next@16.2.12(@playwright/test@1.62.0)(@types/node@26.1.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2435,6 +2435,11 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  baseline-browser-mapping@2.11.1:
+    resolution: {integrity: sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   baseline-browser-mapping@2.11.3:
     resolution: {integrity: sha512-sbT0Ui/CZwyAyy7icT1Gw5P1LKRlFaHwaF6tDCW5YHq2X5SeeZFphBuIagopSfwSSZq3sQcbmEL072yphxm7ew==}
     engines: {node: '>=6.0.0'}
@@ -6544,6 +6549,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  baseline-browser-mapping@2.11.1: {}
+
   baseline-browser-mapping@2.11.3: {}
 
   brace-expansion@1.1.16:
@@ -6561,7 +6568,7 @@ snapshots:
 
   browserslist@4.28.7:
     dependencies:
-      baseline-browser-mapping: 2.11.3
+      baseline-browser-mapping: 2.11.1
       caniuse-lite: 1.0.30001806
       electron-to-chromium: 1.5.395
       node-releases: 2.0.51
@@ -7523,7 +7530,7 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
   flat-cache@6.1.23:

--- a/src/app/_components/dashboard/dashboard-statistics.tsx
+++ b/src/app/_components/dashboard/dashboard-statistics.tsx
@@ -1,5 +1,5 @@
 import dynamic from 'next/dynamic'
-import { Link } from 'next-view-transitions'
+import Link from 'next/link'
 import { memo } from 'react'
 import { LINKS } from '~/constants/links'
 import type { AscentListProps } from '~/schema/ascent.ts'

--- a/src/app/_components/link/link.test.tsx
+++ b/src/app/_components/link/link.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { usePathname } from 'next/navigation'
+import { describe, expect, it, vi } from 'vitest'
+import { Link } from './link'
+
+vi.mock(import('next/navigation'), async (importOriginal) => ({
+  ...(await importOriginal()),
+  usePathname: vi.fn<() => string>(),
+}))
+
+const usePathnameMock = vi.mocked(usePathname)
+
+describe('link', () => {
+  it('preserves active state and click handling for the current route', async () => {
+    const handleClick = vi.fn<() => void>()
+    usePathnameMock.mockReturnValue('/settings')
+    render(
+      <Link className="custom" href="/settings" onClick={handleClick}>
+        Settings
+      </Link>,
+    )
+
+    const link = screen.getByRole('link', { name: 'Settings' })
+    await userEvent.click(link)
+
+    expect(link).toHaveAttribute('href', '/settings')
+    expect(link).toHaveAttribute('data-active', 'true')
+    expect(link).toHaveClass('custom')
+    expect(handleClick).toHaveBeenCalledOnce()
+  })
+})

--- a/src/app/_components/link/link.tsx
+++ b/src/app/_components/link/link.tsx
@@ -1,7 +1,7 @@
 'use client'
 
+import NextLink from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Link as NextLink } from 'next-view-transitions'
 import { memo, type ReactNode } from 'react'
 import styles from './link.module.css'
 

--- a/src/app/_components/training-dashboard/dashboard-stats.tsx
+++ b/src/app/_components/training-dashboard/dashboard-stats.tsx
@@ -1,5 +1,5 @@
 import dynamic from 'next/dynamic'
-import { Link } from 'next-view-transitions'
+import Link from 'next/link'
 import { memo } from 'react'
 import { LINKS } from '~/constants/links'
 import type { TrainingSessionListProps } from '~/schema/training.ts'

--- a/src/app/_components/year-navigation-button/year-navigation-button.tsx
+++ b/src/app/_components/year-navigation-button/year-navigation-button.tsx
@@ -1,6 +1,6 @@
 import { isValidNumber } from '@edouardmisset/math/is-valid.ts'
 import { ArrowLeftCircleIcon, ArrowRightCircleIcon } from 'lucide-react'
-import { Link } from 'next-view-transitions'
+import Link from 'next/link'
 import styles from './year-navigation-button.module.css'
 
 export function YearNavigationButton({

--- a/src/app/ascent-form/_components/ascent-form.tsx
+++ b/src/app/ascent-form/_components/ascent-form.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useTransitionRouter } from 'next-view-transitions'
+import { useRouter } from 'next/navigation'
 import { type ChangeEventHandler, useCallback } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'react-toastify'
@@ -60,7 +60,7 @@ const profileOptions = createValueAndLabel(PROFILES)
 export default function AscentForm(props: AscentFormProps) {
   'use no memo'
   const { latestAscent, maxGrade, minGrade, areas, crags } = props
-  const router = useTransitionRouter()
+  const router = useRouter()
 
   const defaultAscentToParse = {
     area: latestAscent?.area,

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,10 +4,9 @@ import { ClerkProvider } from '@clerk/nextjs'
 import { dark } from '@clerk/themes'
 import { Analytics } from '@vercel/analytics/react'
 import { SpeedInsights } from '@vercel/speed-insights/next'
-import { ViewTransitions } from 'next-view-transitions'
 import { Atkinson_Hyperlegible as atkinson_Hyperlegible } from 'next/font/google'
 import { NuqsAdapter } from 'nuqs/adapters/next/app'
-import { type ReactNode, Suspense } from 'react'
+import { type ReactNode, Suspense, ViewTransition } from 'react'
 import { ToastContainer } from 'react-toastify'
 import { Header } from '~/app/_components/header/header.tsx'
 import { Loader } from '~/app/_components/ui/loader/loader'
@@ -56,38 +55,38 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   }
 
   return (
-    <ViewTransitions>
-      <ClerkProvider appearance={clerkAppearance}>
-        <html
-          className={font.className}
-          data-color-scheme={theme}
-          data-scroll-behavior="smooth"
-          lang={APP_LANGUAGE}
-          suppressHydrationWarning
-        >
-          <body className={styles.body}>
-            <a className={styles.skipLink} href="#main-content">
-              Skip to content
-            </a>
-            <Header />
-            <main className={styles.main} id="main-content" tabIndex={-1}>
-              <Suspense fallback={<Loader />}>
+    <ClerkProvider appearance={clerkAppearance}>
+      <html
+        className={font.className}
+        data-color-scheme={theme}
+        data-scroll-behavior="smooth"
+        lang={APP_LANGUAGE}
+        suppressHydrationWarning
+      >
+        <body className={styles.body}>
+          <a className={styles.skipLink} href="#main-content">
+            Skip to content
+          </a>
+          <Header />
+          <main className={styles.main} id="main-content" tabIndex={-1}>
+            <Suspense fallback={<Loader />}>
+              <ViewTransition>
                 <NuqsAdapter>{children}</NuqsAdapter>
-              </Suspense>
-            </main>
+              </ViewTransition>
+            </Suspense>
+          </main>
 
-            <ToastContainer
-              closeOnClick
-              draggable
-              draggableDirection="x"
-              draggablePercent={20}
-              theme="colored"
-            />
-            <SpeedInsights />
-            <Analytics />
-          </body>
-        </html>
-      </ClerkProvider>
-    </ViewTransitions>
+          <ToastContainer
+            closeOnClick
+            draggable
+            draggableDirection="x"
+            draggablePercent={20}
+            theme="colored"
+          />
+          <SpeedInsights />
+          <Analytics />
+        </body>
+      </html>
+    </ClerkProvider>
   )
 }

--- a/src/app/training-session-form/_components/training-session-form.tsx
+++ b/src/app/training-session-form/_components/training-session-form.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { stringifyDate } from '@edouardmisset/date/convert-string-date.ts'
-import { useTransitionRouter } from 'next-view-transitions'
+import { useRouter } from 'next/navigation'
 import { useForm } from 'react-hook-form'
 import { toast } from 'react-toastify'
 import styles from '~/app/_components/forms/form.module.css'
@@ -43,7 +43,7 @@ import {
 
 export default function TrainingSessionForm({ allLocations }: { allLocations: string[] }) {
   'use no memo'
-  const router = useTransitionRouter()
+  const router = useRouter()
 
   const defaultDate = stringifyDate(new Date())
 

--- a/tests/view-transitions.spec.ts
+++ b/tests/view-transitions.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test'
+
+const appURL = process.env.APP_URL ?? ''
+
+test.describe('view transitions', () => {
+  test('uses a native view transition for client navigation', async ({ page }) => {
+    await page.addInitScript(() => {
+      const startViewTransition = document.startViewTransition.bind(document)
+
+      document.startViewTransition = (...args) => {
+        globalThis.sessionStorage.setItem('view-transition-argument', typeof args[0])
+        return startViewTransition(...args)
+      }
+    })
+    await page.goto(`${appURL}/`)
+
+    await page
+      .getByRole('navigation', { name: 'Public navigation' })
+      .getByRole('link', { name: 'Terms' })
+      .click()
+
+    await expect(page).toHaveURL(/\/terms$/)
+    await expect
+      .poll(() =>
+        page.evaluate(() => globalThis.sessionStorage.getItem('view-transition-argument')),
+      )
+      .toBe('object')
+  })
+
+  test('navigates when view transitions are unsupported', async ({ page }) => {
+    await page.addInitScript(() => {
+      Object.defineProperty(Document.prototype, 'startViewTransition', {
+        configurable: true,
+        value: undefined,
+      })
+    })
+    await page.goto(`${appURL}/`)
+
+    await page
+      .getByRole('navigation', { name: 'Public navigation' })
+      .getByRole('link', { name: 'Terms' })
+      .click()
+
+    await expect(page).toHaveURL(/\/terms$/)
+    await expect(page.getByRole('heading', { name: 'Beta terms' })).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

- enable the native Next.js view transition integration
- replace `next-view-transitions` links and router hooks with Next.js APIs
- remove the third-party dependency and add native/fallback navigation coverage

## Validation

- `pnpm run check`
- `pnpm run test:unit:silent` — 422 tests passed
- `pnpm run build`
- Playwright — native transition and unsupported-browser scenarios passed
- visual QA and final code review passed

Closes #101

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled smoother visual transitions during page navigation.
  - Added support for graceful navigation when view transitions are unavailable.

- **Bug Fixes**
  - Preserved link behavior, active states, custom styling, and click handling across the application.

- **Tests**
  - Added coverage validating navigation transitions and fallback behavior in supported and unsupported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->