### PR TITLE
feat: focus current date in calendar

### DIFF
--- a/src/app/_components/year-grid/empty-grid-cell.tsx
+++ b/src/app/_components/year-grid/empty-grid-cell.tsx
@@ -5,15 +5,18 @@ import styles from './year-grid.module.css'
 type EmptyGridCellProps = {
   cellStyle: CSSProperties
   date: string
+  isToday?: boolean
 }
 
 function EmptyGridCellComponent(props: EmptyGridCellProps) {
-  const { cellStyle, date } = props
+  const { cellStyle, date, isToday = false } = props
 
   return (
     <span
       className={`${styles.yearGridCell} ${styles.emptyGridCell}`}
+      data-today={isToday || undefined}
       style={cellStyle}
+      tabIndex={isToday ? -1 : undefined}
       // Here no data is available for the date, so we only display the date itself
       title={prettyLongDate(date)}
     />

--- a/src/app/_components/year-grid/year-grid-cell.tsx
+++ b/src/app/_components/year-grid/year-grid-cell.tsx
@@ -32,6 +32,7 @@ export const YearGridCell = memo((props: YearGridCellProps) => {
     ascents,
     trainingSessions,
   } = props
+  const isToday = date !== '' && datesEqual(new Date(date), new Date())
 
   const cellStyle: CSSProperties = useMemo(
     () => ({
@@ -83,14 +84,15 @@ export const YearGridCell = memo((props: YearGridCellProps) => {
   }, [ascents, trainingSessions])
 
   if (date === '' || !isDateInYear(date, year))
-    return <EmptyGridCell cellStyle={cellStyle} date={date} />
+    return <EmptyGridCell cellStyle={cellStyle} date={date} isToday={isToday} />
 
   if (lazyDescription === '' || date === '')
-    return <EmptyGridCell cellStyle={cellStyle} date={date} />
+    return <EmptyGridCell cellStyle={cellStyle} date={date} isToday={isToday} />
 
   return (
     <Popover
       className={`${styles.yearGridCell} ${isSpecialCase ? styles.specialCase : ''} contrastColor`}
+      data-today={isToday || undefined}
       popoverTitle={title}
       style={cellStyle}
       trigger={shortText}

--- a/src/app/_components/year-grid/year-grid.test.tsx
+++ b/src/app/_components/year-grid/year-grid.test.tsx
@@ -1,0 +1,56 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vite-plus/test'
+import { YearGrid } from './year-grid'
+
+describe('year grid', () => {
+  it('focuses and centers today when the displayed year contains it', () => {
+    const scrollIntoView = vi.fn<() => void>()
+    HTMLElement.prototype.scrollIntoView = scrollIntoView
+    const today = new Date()
+    today.setHours(12, 0, 0, 0)
+
+    const { container } = render(
+      <YearGrid
+        dayCollection={[
+          {
+            date: today.toISOString(),
+            shortText: '',
+            title: 'Today',
+          },
+        ]}
+        year={today.getFullYear()}
+      />,
+    )
+
+    const todayCell = container.querySelector<HTMLElement>('[data-today="true"]')
+
+    expect(todayCell).toHaveFocus()
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      block: 'nearest',
+      inline: 'center',
+    })
+  })
+
+  it('does not move focus when the displayed year does not contain today', () => {
+    const scrollIntoView = vi.fn<() => void>()
+    HTMLElement.prototype.scrollIntoView = scrollIntoView
+    const previousYear = new Date().getFullYear() - 1
+
+    render(
+      <YearGrid
+        dayCollection={[
+          {
+            date: `${previousYear}-01-01T12:00:00.000Z`,
+            shortText: '',
+            title: 'Past date',
+          },
+        ]}
+        year={previousYear}
+      />,
+    )
+
+    expect(document.body).toHaveFocus()
+    expect(scrollIntoView).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/_components/year-grid/year-grid.tsx
+++ b/src/app/_components/year-grid/year-grid.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { memo, type ReactNode, useMemo } from 'react'
+import { memo, type ReactNode, useEffect, useMemo, useRef } from 'react'
 import { DAYS_IN_WEEK, NOON_HOUR, WEEKS_IN_YEAR } from '~/constants/generic.ts'
 import { prettyLongDate } from '~/helpers/formatters.ts'
 import type { Ascent } from '~/schema/ascent'
@@ -18,6 +18,7 @@ const PREVIOUS_MONDAY_OFFSET = 6
 
 export const YearGrid = memo(
   ({ dayCollection, year }: { year: number; dayCollection: DayDescriptor[] }) => {
+    const gridReference = useRef<HTMLDivElement>(null)
     const displayedNumberOfWeeks = Math.ceil((getNumberOfDaysInYear(year) + 1) / DAYS_IN_WEEK)
     const firstDayOfYear = new Date(year, 0, 1, NOON_HOUR)
     const firstDayIndex = firstDayOfYear.getUTCDay()
@@ -61,8 +62,17 @@ export const YearGrid = memo(
       [numberOfColumns],
     )
 
+    useEffect(() => {
+      const todayCell = gridReference.current?.querySelector<HTMLElement>('[data-today="true"]')
+
+      if (!todayCell) return
+
+      todayCell.focus({ preventScroll: true })
+      todayCell.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'center' })
+    }, [])
+
     return (
-      <div className={styles.yearGrid} style={gridTemplateStyle}>
+      <div className={styles.yearGrid} ref={gridReference} style={gridTemplateStyle}>
         <DaysColumn />
         <WeeksRow columns={columns} />
         {allDayCollection.map(


### PR DESCRIPTION
## Summary

- identify the current-day cell in yearly calendars
- programmatically focus and center that cell when its year is displayed
- keep empty current-day cells programmatically focusable
- cover current-year and historical-year behavior with regression tests

## Impact

Calendar pages now open at today when the displayed calendar contains the current date, making the relevant cell immediately visible.

## Validation

- `vp test --reporter=dot` — 65 files, 424 tests passed
- `vp check` — formatting, lint, and type checks passed

Closes #102
