### PR TITLE
Replace popovers with native hover-aware controls

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -16,6 +16,7 @@
     "declaration-block-no-redundant-longhand-properties": null,
     "block-no-empty": true,
     "color-no-invalid-hex": true,
+    "selector-pseudo-class-no-unknown": [true, { "ignorePseudoClasses": ["interest-source"] }],
     "unit-no-unknown": true,
     "color-no-hex": true,
     "color-function-notation": ["modern", { "ignore": ["with-var-inside"] }]

--- a/src/app/_components/barcode/ascents-bar.tsx
+++ b/src/app/_components/barcode/ascents-bar.tsx
@@ -50,7 +50,13 @@ export const AscentsBar = ({ weeklyAscents }: AscentsBarsProps) => {
   } ${styles.bar}`
 
   return (
-    <Popover className={triggerClassName} popoverTitle={title} style={buttonStyle} trigger=''>
+    <Popover
+      className={triggerClassName}
+      popoverTitle={title}
+      showOnInterest
+      style={buttonStyle}
+      trigger=''
+    >
       {lazyDescription}
     </Popover>
   )

--- a/src/app/_components/barcode/training-bar.tsx
+++ b/src/app/_components/barcode/training-bar.tsx
@@ -57,6 +57,7 @@ export const TrainingBar = ({ weeklyTraining }: TrainingBarsProps) => {
     <Popover
       className={trainingBarClassName}
       popoverTitle={getTrainingSessionSummary(filteredSortedWeeklyTraining)}
+      showOnInterest
       style={buttonStyle}
       trigger=''
     >

--- a/src/app/_components/qr-code/ascents-qr-dot.tsx
+++ b/src/app/_components/qr-code/ascents-qr-dot.tsx
@@ -36,6 +36,7 @@ export const AscentsQRDot = ({ ascents }: { ascents?: Ascent[] }) => {
       aria-label={`Ascent on ${dateAndCrag}`}
       className={gradeClassName}
       popoverTitle={dateAndCrag}
+      showOnInterest
       trigger=''
     >
       {lazyDescription}

--- a/src/app/_components/qr-code/trainings-qr-dot.tsx
+++ b/src/app/_components/qr-code/trainings-qr-dot.tsx
@@ -27,7 +27,7 @@ export const TrainingsQRDot = ({ trainingSessions }: { trainingSessions: Trainin
   )
 
   return (
-    <Popover className={sessionClassName} popoverTitle={formattedDate} trigger=''>
+    <Popover className={sessionClassName} popoverTitle={formattedDate} showOnInterest trigger=''>
       {lazyDescription}
     </Popover>
   )

--- a/src/app/_components/ui/base-ui/base-ui-primitives.module.css
+++ b/src/app/_components/ui/base-ui/base-ui-primitives.module.css
@@ -12,7 +12,7 @@
     }
   }
 
-  &:is(:active, [data-popup-open]) {
+  &:is(:active, :has(+ :popover-open)) {
     background-color: var(--interactive-control-active-bg);
   }
 
@@ -49,30 +49,6 @@
   @media (prefers-color-scheme: dark) {
     outline: 1px solid var(--gray-7);
     outline-offset: -1px;
-  }
-}
-
-.popupArrow {
-  display: flex;
-
-  &[data-side='top'] {
-    inset-block-end: -8px;
-    rotate: 180deg;
-  }
-
-  &[data-side='bottom'] {
-    inset-block-start: -8px;
-    rotate: 0deg;
-  }
-
-  &[data-side='left'] {
-    inset-inline-end: -13px;
-    rotate: 90deg;
-  }
-
-  &[data-side='right'] {
-    inset-inline-start: -13px;
-    rotate: -90deg;
   }
 }
 

--- a/src/app/_components/ui/popover/popover.module.css
+++ b/src/app/_components/ui/popover/popover.module.css
@@ -48,6 +48,21 @@
   transform: scale(1);
 }
 
+.hint {
+  pointer-events: none;
+}
+
+button[interestfor] {
+  transition: transform 150ms;
+}
+
+button[interestfor]:interest-source {
+  z-index: 1;
+  outline: 2px solid currentcolor;
+  outline-offset: 1px;
+  transform: scale(1.1);
+}
+
 .arrow {
   position: absolute;
   inset-block-start: calc(var(--size-2) * -1);

--- a/src/app/_components/ui/popover/popover.module.css
+++ b/src/app/_components/ui/popover/popover.module.css
@@ -14,17 +14,45 @@
 }
 
 .popup {
+  position: fixed;
+  position-area: block-end span-inline-end;
+  position-try-fallbacks: flip-block;
   display: flex;
   flex-direction: column;
   gap: var(--size-fluid-1);
+  margin-block-start: var(--size-2);
   padding-block: var(--size-3);
   padding-inline: var(--size-5);
+
+  opacity: 0;
+  transform: scale(0.9);
 
   border-radius: var(--size-2);
 
   @media (prefers-reduced-motion: no-preference) {
-    transition: all 150ms;
+    transition:
+      opacity 150ms,
+      transform 150ms,
+      display 150ms allow-discrete,
+      overlay 150ms allow-discrete;
+
+    @starting-style {
+      opacity: 0;
+      transform: scale(0.9);
+    }
   }
+}
+
+.popup:popover-open {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.arrow {
+  position: absolute;
+  inset-block-start: calc(var(--size-2) * -1);
+  inset-inline-end: var(--size-4);
+  display: flex;
 }
 
 .title {

--- a/src/app/_components/ui/popover/popover.test.tsx
+++ b/src/app/_components/ui/popover/popover.test.tsx
@@ -29,14 +29,46 @@ describe('popover', () => {
     await expect.element(content).not.toBeVisible()
   })
 
-  it('adds a native hint popover when interest enhancement is enabled', async () => {
-    const { container } = await render(
+  it('shows a native hint popover while its trigger is hovered', async () => {
+    const screen = await render(
       <Popover popoverTitle='Details' showOnInterest trigger='Open details'>
         Popover content
       </Popover>,
     )
 
-    expect(container.innerHTML).toContain('interestfor=')
-    expect(container.innerHTML).toContain('popover="hint"')
+    const trigger = screen.getByRole('button', { name: 'Open details' })
+    const hint = screen.container.querySelector<HTMLElement>('[popover="hint"]')
+
+    if (!hint) throw new Error('Expected a hint popover')
+
+    await trigger.hover()
+
+    await expect.element(hint).toBeVisible()
+  })
+
+  it('only shows the hint for the most recently hovered trigger', async () => {
+    const screen = await render(
+      <>
+        <Popover popoverTitle='First details' showOnInterest trigger='First'>
+          First content
+        </Popover>
+        <Popover popoverTitle='Second details' showOnInterest trigger='Second'>
+          Second content
+        </Popover>
+      </>,
+    )
+
+    const [firstHint, secondHint] =
+      screen.container.querySelectorAll<HTMLElement>('[popover="hint"]')
+
+    if (!firstHint || !secondHint) throw new Error('Expected two hint popovers')
+
+    await screen.getByRole('button', { name: 'First' }).hover()
+    await expect.element(firstHint).toBeVisible()
+
+    await screen.getByRole('button', { name: 'Second' }).hover()
+
+    await expect.element(firstHint).not.toBeVisible()
+    await expect.element(secondHint).toBeVisible()
   })
 })

--- a/src/app/_components/ui/popover/popover.test.tsx
+++ b/src/app/_components/ui/popover/popover.test.tsx
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vite-plus/test'
+import { render } from 'vitest-browser-react'
+import { Popover } from './popover'
+
+describe('popover', () => {
+  it('opens from its trigger and closes when the user clicks outside', async () => {
+    const screen = await render(
+      <>
+        <button type='button'>Outside</button>
+        <Popover aria-label='Show details' popoverTitle='Details' trigger='Open details'>
+          Popover content
+        </Popover>
+      </>,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Show details' })
+    const content = screen.getByText('Popover content')
+
+    await expect.element(trigger).toHaveAttribute('popovertarget')
+    await expect.element(trigger).toHaveAttribute('type', 'button')
+
+    await trigger.click()
+
+    await expect.element(content).toBeVisible()
+    await expect.element(screen.getByRole('heading', { name: 'Details' })).toBeVisible()
+
+    await screen.getByRole('button', { name: 'Outside' }).click()
+
+    await expect.element(content).not.toBeVisible()
+  })
+})

--- a/src/app/_components/ui/popover/popover.test.tsx
+++ b/src/app/_components/ui/popover/popover.test.tsx
@@ -28,4 +28,15 @@ describe('popover', () => {
 
     await expect.element(content).not.toBeVisible()
   })
+
+  it('adds a native hint popover when interest enhancement is enabled', async () => {
+    const { container } = await render(
+      <Popover popoverTitle='Details' showOnInterest trigger='Open details'>
+        Popover content
+      </Popover>,
+    )
+
+    expect(container.innerHTML).toContain('interestfor=')
+    expect(container.innerHTML).toContain('popover="hint"')
+  })
 })

--- a/src/app/_components/ui/popover/popover.tsx
+++ b/src/app/_components/ui/popover/popover.tsx
@@ -1,7 +1,6 @@
 'use client'
 
-import { Popover as BasePopover } from '@base-ui/react/popover'
-import type { ComponentPropsWithoutRef, ReactNode } from 'react'
+import { useId, type ComponentPropsWithoutRef, type ReactNode } from 'react'
 import { Arrow } from '../../svg/arrow/arrow'
 import baseUiStyles from '../base-ui/base-ui-primitives.module.css'
 import styles from './popover.module.css'
@@ -10,34 +9,37 @@ type PopoverProps = {
   trigger: ReactNode
   popoverTitle: ReactNode
   children: ReactNode
-} & Omit<ComponentPropsWithoutRef<typeof BasePopover.Trigger>, 'children'>
+} & Omit<ComponentPropsWithoutRef<'button'>, 'children' | 'type'>
 
 export function Popover(props: PopoverProps) {
   const { trigger, popoverTitle, children, className = '', ...triggerProps } = props
+  const id = useId().replaceAll(':', '')
+  const popupId = `popover-${id}`
+  const titleId = `${popupId}-title`
 
   if (trigger === undefined || popoverTitle === undefined || children === undefined) return
 
   const triggerClass = `${baseUiStyles.interactiveControl} ${styles.iconButton}${typeof className === 'string' ? ` ${className}` : ''}`
 
   return (
-    <BasePopover.Root>
-      <BasePopover.Trigger {...triggerProps} className={triggerClass}>
+    <>
+      <button {...triggerProps} className={triggerClass} popoverTarget={popupId} type='button'>
         {trigger}
-      </BasePopover.Trigger>
-      <BasePopover.Portal>
-        <BasePopover.Positioner sideOffset={8}>
-          <BasePopover.Popup className={`${baseUiStyles.popupSurface} ${styles.popup}`}>
-            <BasePopover.Arrow className={baseUiStyles.popupArrow}>
-              <Arrow />
-            </BasePopover.Arrow>
-            <BasePopover.Title className={styles.title}>{popoverTitle}</BasePopover.Title>
-            <BasePopover.Description
-              className={styles.description}
-              render={<div>{children}</div>}
-            />
-          </BasePopover.Popup>
-        </BasePopover.Positioner>
-      </BasePopover.Portal>
-    </BasePopover.Root>
+      </button>
+      <div
+        aria-labelledby={titleId}
+        className={`${baseUiStyles.popupSurface} ${styles.popup}`}
+        id={popupId}
+        popover='auto'
+      >
+        <div className={styles.arrow}>
+          <Arrow />
+        </div>
+        <h2 className={styles.title} id={titleId}>
+          {popoverTitle}
+        </h2>
+        <div className={styles.description}>{children}</div>
+      </div>
+    </>
   )
 }

--- a/src/app/_components/ui/popover/popover.tsx
+++ b/src/app/_components/ui/popover/popover.tsx
@@ -9,13 +9,24 @@ type PopoverProps = {
   trigger: ReactNode
   popoverTitle: ReactNode
   children: ReactNode
+  showOnInterest?: boolean
 } & Omit<ComponentPropsWithoutRef<'button'>, 'children' | 'type'>
 
 export function Popover(props: PopoverProps) {
-  const { trigger, popoverTitle, children, className = '', ...triggerProps } = props
+  const {
+    trigger,
+    popoverTitle,
+    children,
+    className = '',
+    showOnInterest = false,
+    ...triggerProps
+  } = props
   const id = useId().replaceAll(':', '')
   const popupId = `popover-${id}`
   const titleId = `${popupId}-title`
+  const hintId = `${popupId}-hint`
+  const hintTitleId = `${hintId}-title`
+  const interestProps = showOnInterest ? { interestfor: hintId } : {}
 
   if (trigger === undefined || popoverTitle === undefined || children === undefined) return
 
@@ -23,7 +34,13 @@ export function Popover(props: PopoverProps) {
 
   return (
     <>
-      <button {...triggerProps} className={triggerClass} popoverTarget={popupId} type='button'>
+      <button
+        {...triggerProps}
+        {...interestProps}
+        className={triggerClass}
+        popoverTarget={popupId}
+        type='button'
+      >
         {trigger}
       </button>
       <div
@@ -40,6 +57,22 @@ export function Popover(props: PopoverProps) {
         </h2>
         <div className={styles.description}>{children}</div>
       </div>
+      {showOnInterest && (
+        <div
+          aria-hidden='true'
+          className={`${baseUiStyles.popupSurface} ${styles.popup} ${styles.hint}`}
+          id={hintId}
+          popover='hint'
+        >
+          <div className={styles.arrow}>
+            <Arrow />
+          </div>
+          <h2 className={styles.title} id={hintTitleId}>
+            {popoverTitle}
+          </h2>
+          <div className={styles.description}>{children}</div>
+        </div>
+      )}
     </>
   )
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,8 @@ const compileTarget = 'esnext'
 // React behavior belongs to the integration suite. Charts (recharts'
 // ResponsiveContainer needs real layout/ResizeObserver) and other highly
 // visual components are exercised in a real browser instead of happy-dom.
-const BROWSER_TEST_GLOB = 'src/app/_components/{charts,data-calendar,qr-code,barcode}/**/*.test.tsx'
+const BROWSER_TEST_GLOB =
+  'src/app/_components/{charts,data-calendar,qr-code,barcode,ui/popover}/**/*.test.tsx'
 const VISUAL_TEST_GLOB =
   'src/app/_components/{charts,data-calendar,qr-code,barcode}/**/*.visual.test.tsx'
 const DOM_INTEGRATION_TEST_GLOB = 'src/**/*.test.tsx'


### PR DESCRIPTION
## Summary

- replace the Base UI popover implementation with native HTML popover primitives
- show QR-code and barcode details on hover while preserving click/tap behavior
- rely on native hint-popover exclusivity so the latest hovered trigger wins
- add browser regression coverage for opening, outside-click dismissal, hover display, and hover handoff

## Validation

- `vp check --fix`
- `vp test --project=integration-browser` (22 files, 24 tests)

Closes #125
Closes #119